### PR TITLE
Namespace realocation

### DIFF
--- a/Battle/BattleData.cs
+++ b/Battle/BattleData.cs
@@ -2,78 +2,82 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-[CreateAssetMenu (menuName = "BattleData")]
-public class BattleData : ScriptableObject
+namespace pokeCopy
 {
-    PlayerMovement player;
-    TrainerController trainer;
-    PokemonParty playerParty;
-    PokemonParty trainerParty;
-    Pokemon wildPokemon;
-    [SerializeField] AnimatorOverrideController wildOverride;
-    [SerializeField] AnimatorOverrideController trainerOverride;
 
-    public bool Won { get; set; }
-
-    public bool IsTrainerBattle { get; set; }
-
-    public void ClearData()
+    [CreateAssetMenu(menuName = "BattleData")]
+    public class BattleData : ScriptableObject
     {
-        player = null;
-        trainer = null;
-        trainerParty = null;
-        playerParty  = null;
-        wildPokemon = null;
-        IsTrainerBattle = false;
-        Won = false;
+        PlayerMovement player;
+        TrainerController trainer;
+        PokemonParty playerParty;
+        PokemonParty trainerParty;
+        Pokemon wildPokemon;
+        [SerializeField] AnimatorOverrideController wildOverride;
+        [SerializeField] AnimatorOverrideController trainerOverride;
+
+        public bool Won { get; set; }
+
+        public bool IsTrainerBattle { get; set; }
+
+        public void ClearData()
+        {
+            player = null;
+            trainer = null;
+            trainerParty = null;
+            playerParty = null;
+            wildPokemon = null;
+            IsTrainerBattle = false;
+            Won = false;
+        }
+
+        public void SetTrainer(TrainerController trainer)
+        {
+            this.trainer = trainer;
+            trainerParty = trainer.PokeParty;
+            //use get component?
+        }
+
+        public void SetPlayer(PlayerMovement player)
+        {
+            this.player = player;
+            playerParty = player.GetComponent<PokemonParty>();
+        }
+
+        public PokemonParty GetPlayerParty()
+        {
+            return playerParty;
+        }
+
+        public PokemonParty GetTrainerParty()
+        {
+            return trainerParty;
+        }
+
+        public PlayerMovement GetPlayer()
+        {
+            return player;
+        }
+
+        public TrainerController GetTrainer()
+        {
+            return trainer;
+        }
+
+        public void SetWildPkmn(Pokemon wild)
+        {
+            wildPokemon = wild;
+
+        }
+
+        public Pokemon GetWildPkmn()
+        {
+
+
+            return wildPokemon;
+        }
+
+
+
     }
-
-    public void SetTrainer(TrainerController trainer)
-    {
-        this.trainer = trainer;
-        trainerParty = trainer.PokeParty;
-        //use get component?
-    }
-
-    public void SetPlayer(PlayerMovement player)
-    {
-        this.player = player;
-        playerParty = player.GetComponent<PokemonParty>();
-    }
-
-    public PokemonParty GetPlayerParty()
-    {
-        return playerParty;
-    }
-
-    public PokemonParty GetTrainerParty()
-    {
-        return trainerParty;
-    }
-
-    public PlayerMovement GetPlayer()
-    {
-        return player;
-    }
-
-    public TrainerController GetTrainer()
-    {
-        return trainer;
-    }
-
-    public void SetWildPkmn(Pokemon wild)
-    {
-        wildPokemon = wild;
-
-    }
-
-    public Pokemon GetWildPkmn()
-    {
-
-
-        return wildPokemon;
-    }
-
-    
-
 }

--- a/Battle/BattleHud.cs
+++ b/Battle/BattleHud.cs
@@ -3,195 +3,199 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class BattleHud : MonoBehaviour
+namespace pokeCopy
 {
-    Pokemon poke;
 
-    [SerializeField] Text nameText;
-    [SerializeField] Text LvlText;
-    [SerializeField] Image conditionImg;
-    [SerializeField] Text conditionText;
-    [Space]
-    [SerializeField] Text HPText;
-    //public UIColors colors;
-
-    [SerializeField] Slider HPSlider;
-    Image hpFill;
-    [Space]
-    [SerializeField] Slider XPSlider;
-
-
-    int hpData;
-    bool isUpdating;
-
-    public void SetHUD(Unit unit, bool hidden = false)//TODO: change Unit parameter to Pokemon parameter
+    public class BattleHud : MonoBehaviour
     {
-        if (unit.CrrPokemon != null)
+        Pokemon poke;
+
+        [SerializeField] Text nameText;
+        [SerializeField] Text LvlText;
+        [SerializeField] Image conditionImg;
+        [SerializeField] Text conditionText;
+        [Space]
+        [SerializeField] Text HPText;
+        //public UIColors colors;
+
+        [SerializeField] Slider HPSlider;
+        Image hpFill;
+        [Space]
+        [SerializeField] Slider XPSlider;
+
+
+        int hpData;
+        bool isUpdating;
+
+        public void SetHUD(Unit unit, bool hidden = false)//TODO: change Unit parameter to Pokemon parameter
         {
-            unit.CrrPokemon.OnHPChange -= UpdateHP;
-            unit.CrrPokemon.OnStatusChanged -= SetStatusData;
+            if (unit.CrrPokemon != null)
+            {
+                unit.CrrPokemon.OnHPChange -= UpdateHP;
+                unit.CrrPokemon.OnStatusChanged -= SetStatusData;
 
-        }
-
-
-        if (!hidden)
-            gameObject.SetActive(true);
-        poke = unit.CrrPokemon;
-        nameText.text = unit.CrrPokemon.NickName;
-        UpdateLevel();
-        //LvlText.text = "Lvl " + unit.CrrPokemon.Level;
-        HPSlider.maxValue = unit.CrrPokemon.MaxHP;
-        HPSlider.value = unit.CrrPokemon.HP;
-        SetHP(poke.HP);
-
-        if (HPText)
-        {
-            HPText.text = $"{unit.CrrPokemon.HP}/{unit.CrrPokemon.MaxHP}";
-        }
-
-        SetXp();
-        SetUpXPValue();
-
-        hpFill = HPSlider.fillRect.GetComponent<Image>();
-        unit.CrrPokemon.OnHPChange += UpdateHP;
-        unit.CrrPokemon.OnStatusChanged += SetStatusData;
-        //unit.CrrPokemon.OnChangesInHP.AddListener(SetHP(unit.CrrPokemon.HP));
-        HPColorUpdate();
-        SetStatusData();
-    }
-
-    public void Hide() => gameObject.SetActive(false);
+            }
 
 
-    void SetStatusData()
-    {
-        
-        if (poke.Status == null)
-        {
-            conditionImg.gameObject.SetActive(false);
-            conditionText.text = "";
-        }
-        else
-        {
-            conditionImg.gameObject.SetActive(true);
+            if (!hidden)
+                gameObject.SetActive(true);
+            poke = unit.CrrPokemon;
+            nameText.text = unit.CrrPokemon.NickName;
+            UpdateLevel();
+            //LvlText.text = "Lvl " + unit.CrrPokemon.Level;
+            HPSlider.maxValue = unit.CrrPokemon.MaxHP;
+            HPSlider.value = unit.CrrPokemon.HP;
+            SetHP(poke.HP);
 
-            //conditionImg.color = GameManager.Instance.uiColors.statusColors[poke.Status.Id];
-            conditionImg.color = UIColors.statusColors[poke.Status.Id];
-            conditionText.text = poke.Status.Id.ToString().ToUpper();
-        }
-    }
-
-    void SetHP(int hp) => hpData = hp;
-
-    void SetXp()
-    {
-        if (XPSlider == null)
-            return;
-
-        XPSlider.minValue = poke.Base.GetExpForLevel(poke.Level);
-        XPSlider.maxValue = poke.Base.GetExpForLevel(poke.Level + 1);
-
-
-    }
-
-    void SetUpXPValue()
-    {
-        if (XPSlider != null)
-            XPSlider.value = poke.Exp;
-    }
-
-    public void UpdateLevel()
-    {
-        LvlText.text = "Lvl " + poke.Level;
-        if (HPText)
-        {
-            HPText.text = $"{poke.HP}/{poke.MaxHP}";
-        }
-        HPSlider.maxValue = poke.MaxHP;
-        HPSlider.value = poke.HP;
-
-
-    }
-
-    public IEnumerator UpdateXp_CR(bool reset = false)
-    {
-        if (XPSlider == null) yield break;
-
-        if (reset)
-            SetXp();
-        //float diff = 
-        while (XPSlider.value < poke.Exp && XPSlider.value != XPSlider.maxValue)
-        {
-            XPSlider.value = Mathf.MoveTowards(XPSlider.value, target: poke.Exp, 1f * poke.Level);
-            // Mathf.Lerp(XPSlider.value, poke.Exp, 1f);
-            yield return new WaitForFixedUpdate();
-            if (XPSlider.value > XPSlider.maxValue)//check for errors
-                XPSlider.value = poke.Exp;
-
-        }
-
-    }
-
-    public void UpdateHP()
-    {
-        StartCoroutine(UpdateHP_CR());
-    }
-
-
-    public IEnumerator UpdateHP_CR()
-    {
-        isUpdating = true;
-       // float rate =  ((HPSlider.value - hpData);
-       // float rate = 50* (HPSlider.value - hpData)/(HPSlider.maxValue + hpData);
-        float rate =  (HPSlider.maxValue + (HPSlider.value - poke.HP) +1);
-        
-
-        while (Mathf.Abs(HPSlider.value - poke.HP) > Mathf.Epsilon)//check for errors
-        {
-            //HPSlider.value -= Mathf.Clamp((rate/2 )* 0.008f, -0.95f, 0.95f);
-            HPSlider.value = Mathf.MoveTowards(HPSlider.value, target: poke.HP, Mathf.Abs(rate * Time.deltaTime));
             if (HPText)
-                HPText.text = $"{Mathf.Round(HPSlider.value)}/{HPSlider.maxValue}";
+            {
+                HPText.text = $"{unit.CrrPokemon.HP}/{unit.CrrPokemon.MaxHP}";
+            }
+
+            SetXp();
+            SetUpXPValue();
+
+            hpFill = HPSlider.fillRect.GetComponent<Image>();
+            unit.CrrPokemon.OnHPChange += UpdateHP;
+            unit.CrrPokemon.OnStatusChanged += SetStatusData;
+            //unit.CrrPokemon.OnChangesInHP.AddListener(SetHP(unit.CrrPokemon.HP));
             HPColorUpdate();
-            yield return null;
+            SetStatusData();
         }
-        HPSlider.value = poke.HP;
 
-        isUpdating = false;
-        //configure later so the value is checked on update of value
+        public void Hide() => gameObject.SetActive(false);
+
+
+        void SetStatusData()
+        {
+
+            if (poke.Status == null)
+            {
+                conditionImg.gameObject.SetActive(false);
+                conditionText.text = "";
+            }
+            else
+            {
+                conditionImg.gameObject.SetActive(true);
+
+                //conditionImg.color = GameManager.Instance.uiColors.statusColors[poke.Status.Id];
+                conditionImg.color = UIColors.statusColors[poke.Status.Id];
+                conditionText.text = poke.Status.Id.ToString().ToUpper();
+            }
+        }
+
+        void SetHP(int hp) => hpData = hp;
+
+        void SetXp()
+        {
+            if (XPSlider == null)
+                return;
+
+            XPSlider.minValue = poke.Base.GetExpForLevel(poke.Level);
+            XPSlider.maxValue = poke.Base.GetExpForLevel(poke.Level + 1);
+
+
+        }
+
+        void SetUpXPValue()
+        {
+            if (XPSlider != null)
+                XPSlider.value = poke.Exp;
+        }
+
+        public void UpdateLevel()
+        {
+            LvlText.text = "Lvl " + poke.Level;
+            if (HPText)
+            {
+                HPText.text = $"{poke.HP}/{poke.MaxHP}";
+            }
+            HPSlider.maxValue = poke.MaxHP;
+            HPSlider.value = poke.HP;
+
+
+        }
+
+        public IEnumerator UpdateXp_CR(bool reset = false)
+        {
+            if (XPSlider == null) yield break;
+
+            if (reset)
+                SetXp();
+            //float diff = 
+            while (XPSlider.value < poke.Exp && XPSlider.value != XPSlider.maxValue)
+            {
+                XPSlider.value = Mathf.MoveTowards(XPSlider.value, target: poke.Exp, 1f * poke.Level);
+                // Mathf.Lerp(XPSlider.value, poke.Exp, 1f);
+                yield return new WaitForFixedUpdate();
+                if (XPSlider.value > XPSlider.maxValue)//check for errors
+                    XPSlider.value = poke.Exp;
+
+            }
+
+        }
+
+        public void UpdateHP()
+        {
+            StartCoroutine(UpdateHP_CR());
+        }
+
+
+        public IEnumerator UpdateHP_CR()
+        {
+            isUpdating = true;
+            // float rate =  ((HPSlider.value - hpData);
+            // float rate = 50* (HPSlider.value - hpData)/(HPSlider.maxValue + hpData);
+            float rate = (HPSlider.maxValue + (HPSlider.value - poke.HP) + 1);
+
+
+            while (Mathf.Abs(HPSlider.value - poke.HP) > Mathf.Epsilon)//check for errors
+            {
+                //HPSlider.value -= Mathf.Clamp((rate/2 )* 0.008f, -0.95f, 0.95f);
+                HPSlider.value = Mathf.MoveTowards(HPSlider.value, target: poke.HP, Mathf.Abs(rate * Time.deltaTime));
+                if (HPText)
+                    HPText.text = $"{Mathf.Round(HPSlider.value)}/{HPSlider.maxValue}";
+                HPColorUpdate();
+                yield return null;
+            }
+            HPSlider.value = poke.HP;
+
+            isUpdating = false;
+            //configure later so the value is checked on update of value
+
+        }
+
+
+        void HPColorUpdate()
+        {
+            if (HPSlider.value <= HPSlider.maxValue * 0.25f)
+                hpFill.color = UIColors.hpStateColor[HpState.danger];
+            else if (HPSlider.value <= HPSlider.maxValue * 0.5f)
+                hpFill.color = UIColors.hpStateColor[HpState.caution];
+            else
+                hpFill.color = UIColors.hpStateColor[HpState.healthy];
+
+        }
+
+
+        public IEnumerator WaitHpUpdat_CR()
+        {
+            yield return new WaitUntil(() => isUpdating == false);
+            yield return new WaitForSeconds(0.25f);
+        }
+
+        public void OnDisable()
+        {
+            poke.OnHPChange -= UpdateHP;
+            poke.OnStatusChanged -= SetStatusData;
+
+        }
+
+        public void OnDestroy()
+        {
+            poke.OnHPChange -= UpdateHP;
+            poke.OnStatusChanged -= SetStatusData;
+        }
 
     }
-
-
-    void HPColorUpdate()
-    {
-        if (HPSlider.value <= HPSlider.maxValue * 0.25f)
-            hpFill.color = UIColors.hpStateColor[HpState.danger];
-        else if (HPSlider.value <= HPSlider.maxValue * 0.5f)
-            hpFill.color = UIColors.hpStateColor[HpState.caution];
-        else
-            hpFill.color = UIColors.hpStateColor[HpState.healthy];
-
-    }
-
-
-    public IEnumerator WaitHpUpdat_CR()
-    {
-        yield return new WaitUntil(()=>isUpdating == false);
-        yield return new WaitForSeconds(0.25f);
-    }
-
-    public void OnDisable()
-    {
-        poke.OnHPChange -= UpdateHP;
-        poke.OnStatusChanged -= SetStatusData;
-
-    }
-
-    public void OnDestroy()
-    {
-        poke.OnHPChange -= UpdateHP;
-        poke.OnStatusChanged -= SetStatusData;
-    }
-
 }

--- a/Battle/BattleSystem.cs
+++ b/Battle/BattleSystem.cs
@@ -10,1254 +10,1259 @@ using pokeCopy;
 using System.Linq;
 using System;
 
-public enum BattleState { START, DECISION_PHASE, TURN_RESOLUTION, SWITCHING, FOE_SWITCHING, CATCHING, FORGET_MOVE, END }
-public enum BattleAction { Moves, Switch, UseItem, Run };
 
-public class BattleSystem : MonoBehaviour
+namespace pokeCopy
 {
-    [Header("Data")]
-    [SerializeField] SceneData battlesSceneData;
-    [SerializeField] BattleData battlesData;
+    public enum BattleState { START, DECISION_PHASE, TURN_RESOLUTION, SWITCHING, FOE_SWITCHING, CATCHING, FORGET_MOVE, END }
+    public enum BattleAction { Moves, Switch, UseItem, Run };
 
-    bool isTrainerBattle = false;
-    bool isScene = false;
-
-    PokemonParty playerParty;
-    PokemonParty trainerParty;
-    PokemonTeam trainerTeam;
-    Pokemon wildPokemon;
-
-    TrainerController trainer;
-    TrainerData trainerData;
-
-    public GameObject playerPrefab;
-    public GameObject enemyPrefab;
-
-    [Header("Units Game Objects")]
-    [SerializeField] GameObject pokeBall;
-    [SerializeField] GameObject playerObject;
-    [SerializeField] GameObject enemyObject;
-    [SerializeField] Transform playerBattleStation;
-    [SerializeField] Transform enemyBattleStation;
-    [SerializeField] SpriteRenderer playerChar;
-    [SerializeField] SpriteRenderer trainerChar;
-    [SerializeField] SpriteRenderer background;
-
-    Unit playerUnit;
-    Unit enemyUnit;
-
-    [Header("HUDs")]
-    [SerializeField] BattleHud playerHUD;
-    [SerializeField] BattleHud enemyHUD;
-
-    [Header("SubSystems and Windows")]
-    [SerializeField] PartyScreenUI partyMenu;
-    [SerializeField] InventoryUI inventory;
-    [SerializeField] GameObject choiceDoSwitchMenu;
-    [SerializeField] GameObject partyBattleSelection;
-    [SerializeField] GameObject inventoryPocketSelectionMenu;
-    [SerializeField] ForgetMenuSubMenuUI forgetMoveUI;
-    public DialogueBox dialogueBox;
-    [SerializeField] BattleAnimationsController animations;
-
-    [Space]
-    [Header("State Info")]
-    [SerializeField][ReadOnly] BattleState state;
-    [SerializeField][ReadOnly] BattleState prevState;
-
-    [SerializeField][ReadOnly] int fleeAtempts;
-    [SerializeField][ReadOnly] int crntTurn;
-
-    public BattleState State
+    public class BattleSystem : MonoBehaviour
     {
-        get => state;
-        set
+        [Header("Data")]
+        [SerializeField] SceneData battlesSceneData;
+        [SerializeField] BattleData battlesData;
+
+        bool isTrainerBattle = false;
+        bool isScene = false;
+
+        PokemonParty playerParty;
+        PokemonParty trainerParty;
+        PokemonTeam trainerTeam;
+        Pokemon wildPokemon;
+
+        TrainerController trainer;
+        TrainerData trainerData;
+
+        public GameObject playerPrefab;
+        public GameObject enemyPrefab;
+
+        [Header("Units Game Objects")]
+        [SerializeField] GameObject pokeBall;
+        [SerializeField] GameObject playerObject;
+        [SerializeField] GameObject enemyObject;
+        [SerializeField] Transform playerBattleStation;
+        [SerializeField] Transform enemyBattleStation;
+        [SerializeField] SpriteRenderer playerChar;
+        [SerializeField] SpriteRenderer trainerChar;
+        [SerializeField] SpriteRenderer background;
+
+        Unit playerUnit;
+        Unit enemyUnit;
+
+        [Header("HUDs")]
+        [SerializeField] BattleHud playerHUD;
+        [SerializeField] BattleHud enemyHUD;
+
+        [Header("SubSystems and Windows")]
+        [SerializeField] PartyScreenUI partyMenu;
+        [SerializeField] InventoryUI inventory;
+        [SerializeField] GameObject choiceDoSwitchMenu;
+        [SerializeField] GameObject partyBattleSelection;
+        [SerializeField] GameObject inventoryPocketSelectionMenu;
+        [SerializeField] ForgetMenuSubMenuUI forgetMoveUI;
+        public DialogueBox dialogueBox;
+        [SerializeField] BattleAnimationsController animations;
+
+        [Space]
+        [Header("State Info")]
+        [SerializeField][ReadOnly] BattleState state;
+        [SerializeField][ReadOnly] BattleState prevState;
+
+        [SerializeField][ReadOnly] int fleeAtempts;
+        [SerializeField][ReadOnly] int crntTurn;
+
+        public BattleState State
         {
-            prevState = state;
-            state = value;
-        }
-    }
-
-    private void Awake()
-    {
-    }
-
-    public void Start()
-    {
-        isScene = GameManager.Instance.IsBattleAScene;
-        if (battlesData == null)
-            battlesData = GameManager.Instance.BattleData;
-
-        partyMenu.SetBattleSelectionMenu(partyBattleSelection);
-        partyMenu.SetButtons(OnSelectFromParty, CancelButtonPartyMenu);
-        // forgetMoveUI.SetButtons();
-    }
-
-    public void OnEnable()
-    {
-        state = BattleState.START;
-        enemyHUD.Hide();
-        playerHUD.Hide();
-        isTrainerBattle = battlesData.IsTrainerBattle;
-
-        if (isScene)
-        {
-            playerParty = battlesSceneData.RetrivePlayerParty();
-            wildPokemon = battlesSceneData.RetriveWildPkmn();
-
-            trainerData = battlesSceneData.RetriveTrainerData();
-            playerChar.sprite = battlesSceneData.PlayerChar;
-            //dialogueBox = GetComponentInChildren<DialogueBox>();
-            //Debug.Log(trainerData == null);
-            // Debug.Log(trainerTeam);
-            if (trainerData != null)
+            get => state;
+            set
             {
-                trainerParty = trainerData.Party;
-                trainerTeam = trainerData.team;
+                prevState = state;
+                state = value;
             }
         }
-        else
+
+        private void Awake()
         {
-            playerChar.sprite = battlesData.GetPlayer().BattleSprite;
-            playerParty = battlesData.GetPlayerParty();
-
-            trainer = battlesData.GetTrainer();
-            if (trainer)
-                trainerChar.sprite = trainer.TrainerChar;
-
-            trainerParty = battlesData.GetTrainerParty();
-
-            wildPokemon = battlesData.GetWildPkmn();
-
-        }
-        StartCoroutine(StartBattle_CR());
-
-    }
-
-    public void Update()
-    {
-        if (Keyboard.current.qKey.wasPressedThisFrame)
-            Application.Quit();
-
-    }
-
-    void ChangeState(BattleState newState)
-    {
-        prevState = state;
-        state = newState;
-    }
-
-    public IEnumerator StartBattle_CR()
-    {
-        playerChar.gameObject.SetActive(true);
-        dialogueBox.SetText("");
-        fleeAtempts = 0;
-        crntTurn = 0;
-
-        if (isTrainerBattle)
-        {
-            trainerChar.gameObject.SetActive(true);
-            //  trainerChar.sprite = trainerData.BattleSrpite;
-            trainerChar.sprite = trainer.TrainerChar;
-
-            yield return dialogueBox.TypeDialougueText_CR($"{trainer.Name} wants to battle.");
-
         }
 
-        StartCoroutine(SetUpBattle_CR());
-    }
-
-
-    IEnumerator SetUpBattle_CR()
-    {
-        trainerChar.gameObject.SetActive(false);
-
-        //Set enemy Unit
-        var enemyPoke = (isTrainerBattle) ? trainerParty.GetHealthy() : wildPokemon;
-        enemyObject.SetActive(true);
-        enemyUnit = enemyObject.GetComponent<Unit>();
-        enemyUnit.SetUpUnit(enemyPoke, enemyHUD);
-
-        //Change start pokemon sprite animation so if traner get out of pokeball aka same animation as playerUnity on Battle_EnemyBegin
-
-        //yield return new WaitForSeconds(0.5f);
-
-        if (isTrainerBattle)
+        public void Start()
         {
-            enemyUnit.SetAnimatorControl(animations.TrainerOverride);
-            yield return dialogueBox.TypeDialougueText_CR($"{trainer.Name} send out a {enemyPoke.Species}.");
-            yield return new WaitForSeconds(.5f);
-            enemyUnit.unitName = "The foe's " + enemyUnit.unitName;
-        }
-        else
-        {
-            enemyUnit.SetAnimatorControl(animations.WildOverride);
-            yield return dialogueBox.TypeDialougueText_CR("A wild " + enemyUnit.unitName + " approaches!");
-            yield return new WaitForSeconds(.5f);
-            enemyUnit.unitName = "The wild " + enemyUnit.unitName;
+            isScene = GameManager.Instance.IsBattleAScene;
+            if (battlesData == null)
+                battlesData = GameManager.Instance.BattleData;
 
+            partyMenu.SetBattleSelectionMenu(partyBattleSelection);
+            partyMenu.SetButtons(OnSelectFromParty, CancelButtonPartyMenu);
+            // forgetMoveUI.SetButtons();
         }
 
-        //Set PlayerUnit
-        playerChar.gameObject.SetActive(false);
-        playerObject.SetActive(true);
-        playerUnit = playerObject.GetComponent<Unit>();
-        playerUnit.SetUpUnit(playerParty.GetHealthy(), playerHUD);
-
-        yield return new WaitForSeconds(1.5f);
-
-        //Change Phase and set move Buttons
-        ChangeState(BattleState.DECISION_PHASE);
-
-        dialogueBox.SetMoveButtons(playerUnit.CrrPokemon.MoveSet);
-
-        DecisionPhase();
-
-    }
-
-
-    IEnumerator SwitchPokemonUnit_CR(Pokemon substitute)
-    {
-        if (playerUnit.CrrPokemon.HP > 0)
+        public void OnEnable()
         {
-            yield return dialogueBox.TypeDialougueText_CR($"Come back, {playerUnit.name}.");
+            state = BattleState.START;
+            enemyHUD.Hide();
+            playerHUD.Hide();
+            isTrainerBattle = battlesData.IsTrainerBattle;
 
-            yield return animations.SwitchPokemon_CR(playerUnit);
-        }
-        playerHUD.Hide();
-        playerUnit.CrrPokemon.RemoveAllVolat();
-
-        yield return new WaitForSeconds(.75f);
-
-        //Set New Unit
-        playerUnit.SetUpUnit(substitute, playerHUD);
-        yield return dialogueBox.TypeDialougueText_CR($"Go {playerUnit.name}!!!");
-
-        dialogueBox.SetMoveButtons(playerUnit.CrrPokemon.MoveSet);
-
-
-        yield return new WaitForSeconds(playerUnit.animator.GetCurrentAnimatorStateInfo(0).length);
-
-
-        yield return new WaitForSeconds(.75f);
-
-        partyMenu.SelectedPokemon = null;
-
-        ChangeState(BattleState.TURN_RESOLUTION);//maybe change?
-    }
-
-
-    void DecisionPhase()
-    {
-
-        if (playerUnit.MoveOfChoice?.isCharged == false)
-        {
-            playerUnit.MoveOfChoice.isCharged = true;
-            StartCoroutine(TurnResolution_CR(BattleAction.Moves));
-            return;
-        }
-
-
-        dialogueBox.SetText("Choose an action.");
-        dialogueBox.SetActionsMenu();
-    }
-
-
-    IEnumerator TurnResolution_CR(BattleAction playerAction)
-    {
-        ChangeState(BattleState.TURN_RESOLUTION);
-        crntTurn++;
-
-
-        //enemy decision
-
-        enemyUnit.SetMoveToUse(playerUnit);
-        //Allow to enmey to run away if wild
-        //enemyUnit.MoveOfChoice = enemyUnit.CrrPokemon.GetRandomMove();
-
-        if (playerAction == BattleAction.Moves)
-        {
-            //Array or list to define order of multple units
-            bool doesPlayerGoesFirst = IsPlayerFirst(playerUnit, enemyUnit);
-
-            var firstUnit = (doesPlayerGoesFirst) ? playerUnit : enemyUnit;
-            var secondUnit = (doesPlayerGoesFirst) ? enemyUnit : playerUnit;
-
-            yield return UseMove_CR(firstUnit, secondUnit, firstUnit.MoveOfChoice);
-            yield return AfterMove_CR(firstUnit);
-            if (state == BattleState.END) yield break;
-
-            if (secondUnit.CrrPokemon.HP > 0 && secondUnit.MoveOfChoice != null)
+            if (isScene)
             {
-                yield return UseMove_CR(secondUnit, firstUnit, secondUnit.MoveOfChoice);
-            }
-            yield return AfterMove_CR(secondUnit);
-            if (state == BattleState.END) yield break;
-        }
-        else
-        {
-            if (playerAction == BattleAction.Switch)
-                yield return SwitchPokemonUnit_CR(partyMenu.SelectedPokemon);
+                playerParty = battlesSceneData.RetrivePlayerParty();
+                wildPokemon = battlesSceneData.RetriveWildPkmn();
 
-            else if (playerAction == BattleAction.Run)
-            {
-                yield return TryToEscape_CR(playerUnit, enemyUnit);
-                if (state == BattleState.END) yield break;
-            }
-            else if (playerAction == BattleAction.UseItem)
-            {
-
-
-                //
-                yield return new WaitForSeconds(0.5f);
-                //play animation
-                /*
-                var itemUsed = inventory.UseItem_OnBattle();
-
-                if (itemUsed is PokeBallItem)
-                    yield return ThrowPokeBall_CR(itemUsed as PokeBallItem);
-                else
+                trainerData = battlesSceneData.RetriveTrainerData();
+                playerChar.sprite = battlesSceneData.PlayerChar;
+                //dialogueBox = GetComponentInChildren<DialogueBox>();
+                //Debug.Log(trainerData == null);
+                // Debug.Log(trainerTeam);
+                if (trainerData != null)
                 {
-                    yield return playerHUD.WaitHpUpdate();
-                    yield return dialogueBox.TypeDialougueText_CR($"Used {itemUsed.name} on {inventory.PartyMenuSelection.SelectedPokemon.NickName}.");
+                    trainerParty = trainerData.Party;
+                    trainerTeam = trainerData.team;
                 }
-                //
-                */
-
-                //yield return ThrowPokeBall_CR();
-                if (state == BattleState.END) yield break;
-
-            }
-
-            yield return UseMove_CR(enemyUnit, playerUnit, enemyUnit.MoveOfChoice);
-            yield return AfterMove_CR(enemyUnit);
-            if (state == BattleState.END) yield break;
-
-        }
-
-
-
-        yield return OnEndOfRound_CR();
-
-        if (state != BattleState.END)
-        {
-            ChangeState(BattleState.DECISION_PHASE);
-            DecisionPhase();
-        }
-    }
-
-    bool IsPlayerFirst(Unit player, Unit enemy)
-    {
-        int player_P = player.MoveOfChoice.Base.Priority;
-        int enemy_P = enemy.MoveOfChoice.Base.Priority;
-
-        int speedDiff = player.CrrPokemon.Speed - enemy.CrrPokemon.Speed;
-
-        if (player_P > enemy_P)
-            return true;
-
-        if (player_P == enemy_P)
-        {
-            if (speedDiff > 0)
-                return true;
-            if (speedDiff == 0)
-                return (UnityEngine.Random.value > 0.5f);
-        }
-
-        return false;
-    }
-
-    IEnumerator UseMove_CR(Unit user, Unit target, Move move)
-    {
-        bool canMove = user.CrrPokemon.BeforeTurnEffects();
-        //play before effect animation
-        if (!canMove)
-        {
-            yield return user.BHud.WaitHpUpdat_CR();
-            yield return ShowEffectsChanges_CR(user);
-            // method returning a bool 
-            if (user.CrrPokemon.HP <= 0)
-            {
-                //
-                //faint animation
-                //
-
-                yield return Fainted_CR(user);
-
-            }
-            //
-
-            yield break;
-        }
-        yield return ShowEffectsChanges_CR(user);
-
-        //Check codition to execute
-        // when selecting
-
-
-        if (move.TurnsBfrHit <= 0)
-            move.Pp--;
-
-
-        //deal with charge moves here
-        //TO DO: Check if use custom used move message for
-
-        yield return dialogueBox.TypeDialougueText_CR($" {user.unitName} used {move.Base.name}", 1f);
-
-        if (MoveHitCheck(move, user, target))
-        {
-            int dmg = 0;
-            if (move.Base.Category == MoveCategory.Status)
-            {
-                yield return animations.AnimateMoveUsage_CR(user, target, move);
-                yield return animations.EffectAnimation_CR(target);
-                yield return RunMoveEffects_CR(move.Base.Effects, user, target, move.Base.Target);
-
             }
             else
             {
-                //&& move.Base.Power != 0
-                if (move.isCharged)// use charge turn move propety instead
+                playerChar.sprite = battlesData.GetPlayer().BattleSprite;
+                playerParty = battlesData.GetPlayerParty();
+
+                trainer = battlesData.GetTrainer();
+                if (trainer)
+                    trainerChar.sprite = trainer.TrainerChar;
+
+                trainerParty = battlesData.GetTrainerParty();
+
+                wildPokemon = battlesData.GetWildPkmn();
+
+            }
+            StartCoroutine(StartBattle_CR());
+
+        }
+
+        public void Update()
+        {
+            if (Keyboard.current.qKey.wasPressedThisFrame)
+                Application.Quit();
+
+        }
+
+        void ChangeState(BattleState newState)
+        {
+            prevState = state;
+            state = newState;
+        }
+
+        public IEnumerator StartBattle_CR()
+        {
+            playerChar.gameObject.SetActive(true);
+            dialogueBox.SetText("");
+            fleeAtempts = 0;
+            crntTurn = 0;
+
+            if (isTrainerBattle)
+            {
+                trainerChar.gameObject.SetActive(true);
+                //  trainerChar.sprite = trainerData.BattleSrpite;
+                trainerChar.sprite = trainer.TrainerChar;
+
+                yield return dialogueBox.TypeDialougueText_CR($"{trainer.Name} wants to battle.");
+
+            }
+
+            StartCoroutine(SetUpBattle_CR());
+        }
+
+
+        IEnumerator SetUpBattle_CR()
+        {
+            trainerChar.gameObject.SetActive(false);
+
+            //Set enemy Unit
+            var enemyPoke = (isTrainerBattle) ? trainerParty.GetHealthy() : wildPokemon;
+            enemyObject.SetActive(true);
+            enemyUnit = enemyObject.GetComponent<Unit>();
+            enemyUnit.SetUpUnit(enemyPoke, enemyHUD);
+
+            //Change start pokemon sprite animation so if traner get out of pokeball aka same animation as playerUnity on Battle_EnemyBegin
+
+            //yield return new WaitForSeconds(0.5f);
+
+            if (isTrainerBattle)
+            {
+                enemyUnit.SetAnimatorControl(animations.TrainerOverride);
+                yield return dialogueBox.TypeDialougueText_CR($"{trainer.Name} send out a {enemyPoke.Species}.");
+                yield return new WaitForSeconds(.5f);
+                enemyUnit.unitName = "The foe's " + enemyUnit.unitName;
+            }
+            else
+            {
+                enemyUnit.SetAnimatorControl(animations.WildOverride);
+                yield return dialogueBox.TypeDialougueText_CR("A wild " + enemyUnit.unitName + " approaches!");
+                yield return new WaitForSeconds(.5f);
+                enemyUnit.unitName = "The wild " + enemyUnit.unitName;
+
+            }
+
+            //Set PlayerUnit
+            playerChar.gameObject.SetActive(false);
+            playerObject.SetActive(true);
+            playerUnit = playerObject.GetComponent<Unit>();
+            playerUnit.SetUpUnit(playerParty.GetHealthy(), playerHUD);
+
+            yield return new WaitForSeconds(1.5f);
+
+            //Change Phase and set move Buttons
+            ChangeState(BattleState.DECISION_PHASE);
+
+            dialogueBox.SetMoveButtons(playerUnit.CrrPokemon.MoveSet);
+
+            DecisionPhase();
+
+        }
+
+
+        IEnumerator SwitchPokemonUnit_CR(Pokemon substitute)
+        {
+            if (playerUnit.CrrPokemon.HP > 0)
+            {
+                yield return dialogueBox.TypeDialougueText_CR($"Come back, {playerUnit.name}.");
+
+                yield return animations.SwitchPokemon_CR(playerUnit);
+            }
+            playerHUD.Hide();
+            playerUnit.CrrPokemon.RemoveAllVolat();
+
+            yield return new WaitForSeconds(.75f);
+
+            //Set New Unit
+            playerUnit.SetUpUnit(substitute, playerHUD);
+            yield return dialogueBox.TypeDialougueText_CR($"Go {playerUnit.name}!!!");
+
+            dialogueBox.SetMoveButtons(playerUnit.CrrPokemon.MoveSet);
+
+
+            yield return new WaitForSeconds(playerUnit.animator.GetCurrentAnimatorStateInfo(0).length);
+
+
+            yield return new WaitForSeconds(.75f);
+
+            partyMenu.SelectedPokemon = null;
+
+            ChangeState(BattleState.TURN_RESOLUTION);//maybe change?
+        }
+
+
+        void DecisionPhase()
+        {
+
+            if (playerUnit.MoveOfChoice?.isCharged == false)
+            {
+                playerUnit.MoveOfChoice.isCharged = true;
+                StartCoroutine(TurnResolution_CR(BattleAction.Moves));
+                return;
+            }
+
+
+            dialogueBox.SetText("Choose an action.");
+            dialogueBox.SetActionsMenu();
+        }
+
+
+        IEnumerator TurnResolution_CR(BattleAction playerAction)
+        {
+            ChangeState(BattleState.TURN_RESOLUTION);
+            crntTurn++;
+
+
+            //enemy decision
+
+            enemyUnit.SetMoveToUse(playerUnit);
+            //Allow to enmey to run away if wild
+            //enemyUnit.MoveOfChoice = enemyUnit.CrrPokemon.GetRandomMove();
+
+            if (playerAction == BattleAction.Moves)
+            {
+                //Array or list to define order of multple units
+                bool doesPlayerGoesFirst = IsPlayerFirst(playerUnit, enemyUnit);
+
+                var firstUnit = (doesPlayerGoesFirst) ? playerUnit : enemyUnit;
+                var secondUnit = (doesPlayerGoesFirst) ? enemyUnit : playerUnit;
+
+                yield return UseMove_CR(firstUnit, secondUnit, firstUnit.MoveOfChoice);
+                yield return AfterMove_CR(firstUnit);
+                if (state == BattleState.END) yield break;
+
+                if (secondUnit.CrrPokemon.HP > 0 && secondUnit.MoveOfChoice != null)
+                {
+                    yield return UseMove_CR(secondUnit, firstUnit, secondUnit.MoveOfChoice);
+                }
+                yield return AfterMove_CR(secondUnit);
+                if (state == BattleState.END) yield break;
+            }
+            else
+            {
+                if (playerAction == BattleAction.Switch)
+                    yield return SwitchPokemonUnit_CR(partyMenu.SelectedPokemon);
+
+                else if (playerAction == BattleAction.Run)
+                {
+                    yield return TryToEscape_CR(playerUnit, enemyUnit);
+                    if (state == BattleState.END) yield break;
+                }
+                else if (playerAction == BattleAction.UseItem)
                 {
 
-                    //play animation coordenated by animation events
-                    //Check for the overheads on assinging animaitons at runtime
-                    /*
-                    user.animator.Play("Battle_EnemyAttack");
-                    target.impact.Play();
 
-                    yield return new WaitForSeconds(user.animator.GetCurrentAnimatorStateInfo(0).length);
+                    //
+                    yield return new WaitForSeconds(0.5f);
+                    //play animation
+                    /*
+                    var itemUsed = inventory.UseItem_OnBattle();
+
+                    if (itemUsed is PokeBallItem)
+                        yield return ThrowPokeBall_CR(itemUsed as PokeBallItem);
+                    else
+                    {
+                        yield return playerHUD.WaitHpUpdate();
+                        yield return dialogueBox.TypeDialougueText_CR($"Used {itemUsed.name} on {inventory.PartyMenuSelection.SelectedPokemon.NickName}.");
+                    }
                     //
                     */
 
+                    //yield return ThrowPokeBall_CR();
+                    if (state == BattleState.END) yield break;
+
+                }
+
+                yield return UseMove_CR(enemyUnit, playerUnit, enemyUnit.MoveOfChoice);
+                yield return AfterMove_CR(enemyUnit);
+                if (state == BattleState.END) yield break;
+
+            }
+
+
+
+            yield return OnEndOfRound_CR();
+
+            if (state != BattleState.END)
+            {
+                ChangeState(BattleState.DECISION_PHASE);
+                DecisionPhase();
+            }
+        }
+
+        bool IsPlayerFirst(Unit player, Unit enemy)
+        {
+            int player_P = player.MoveOfChoice.Base.Priority;
+            int enemy_P = enemy.MoveOfChoice.Base.Priority;
+
+            int speedDiff = player.CrrPokemon.Speed - enemy.CrrPokemon.Speed;
+
+            if (player_P > enemy_P)
+                return true;
+
+            if (player_P == enemy_P)
+            {
+                if (speedDiff > 0)
+                    return true;
+                if (speedDiff == 0)
+                    return (UnityEngine.Random.value > 0.5f);
+            }
+
+            return false;
+        }
+
+        IEnumerator UseMove_CR(Unit user, Unit target, Move move)
+        {
+            bool canMove = user.CrrPokemon.BeforeTurnEffects();
+            //play before effect animation
+            if (!canMove)
+            {
+                yield return user.BHud.WaitHpUpdat_CR();
+                yield return ShowEffectsChanges_CR(user);
+                // method returning a bool 
+                if (user.CrrPokemon.HP <= 0)
+                {
+                    //
+                    //faint animation
+                    //
+
+                    yield return Fainted_CR(user);
+
+                }
+                //
+
+                yield break;
+            }
+            yield return ShowEffectsChanges_CR(user);
+
+            //Check codition to execute
+            // when selecting
+
+
+            if (move.TurnsBfrHit <= 0)
+                move.Pp--;
+
+
+            //deal with charge moves here
+            //TO DO: Check if use custom used move message for
+
+            yield return dialogueBox.TypeDialougueText_CR($" {user.unitName} used {move.Base.name}", 1f);
+
+            if (MoveHitCheck(move, user, target))
+            {
+                int dmg = 0;
+                if (move.Base.Category == MoveCategory.Status)
+                {
                     yield return animations.AnimateMoveUsage_CR(user, target, move);
-                    DamageDetails details = target.TakeMoveDamage(move, user);
-
-                    target.animator.Play("BattleEnemy_Damaged2");
-
-                    yield return new WaitForSeconds(target.animator.GetCurrentAnimatorStateInfo(0).length);
-
-                    yield return target.BHud.WaitHpUpdat_CR();
-
-
-                    dmg = details.Damage;
-                    yield return ShowMoveDetails_CR(details);
+                    yield return animations.EffectAnimation_CR(target);
+                    yield return RunMoveEffects_CR(move.Base.Effects, user, target, move.Base.Target);
 
                 }
                 else
                 {
-                    //play charging animation?
-                    yield return dialogueBox.TypeDialougueText_CR($"{user.name} is charging a attack.");//make constumized for each move
-                }
-            }
-
-            var hitEffect = move.Base.EffectWhenHit;
-            if (hitEffect != HitEffectsID.none)
-            {
-                //TO DO: set this effect on takedamage method, without the need of capturing damage without method
-                ConditionsDB.HitEffects[hitEffect].OnHit?.Invoke(user.CrrPokemon, dmg);
-
-                //Animations
-
-                yield return user.BHud.WaitHpUpdat_CR();
-                var affectd = (hitEffect == HitEffectsID.leech_life) ? target : user;
-                yield return dialogueBox.TypeDialougueText_CR($"{affectd.unitName}{ConditionsDB.HitEffects[hitEffect].Message}");
-
-            }
-            if (target.CrrPokemon.HP <= 0)
-            {
-                yield return Fainted_CR(target);
-                yield break;
-
-            }
-
-
-            if (user.CrrPokemon.HP <= 0)
-            {
-                yield return Fainted_CR(user);
-                yield break;
-            }
-
-
-            if (move.Base.Secundaries != null && move.Base.Secundaries.Count > 0)
-            {
-                foreach (var secondary in move.Base.Secundaries) //(int i = 0; i < move.Base.Secundaries.Count; i++)
-                {
-                    if (secondary.Condition == ConditionID.leech_seed)
-                        continue;
-
-                    if (UnityEngine.Random.Range(1, 101) <= secondary.StatusChance)
+                    //&& move.Base.Power != 0
+                    if (move.isCharged)// use charge turn move propety instead
                     {
-                        var doesHappenOnChargingTurn = ((move.isCharged && secondary.Target == Target.Foe) || (!move.isCharged && secondary.Target == Target.Self));
-                        if (!move.Base.HasChargingTurn || doesHappenOnChargingTurn)
-                            yield return RunMoveEffects_CR(secondary, user, target, secondary.Target);
 
+                        //play animation coordenated by animation events
+                        //Check for the overheads on assinging animaitons at runtime
+                        /*
+                        user.animator.Play("Battle_EnemyAttack");
+                        target.impact.Play();
 
-                        //play animations here? only one execution but need to check if there is no more then two diferente changes, like one up stat, one doen stat, one status change
-                    }
-                }
-            }
+                        yield return new WaitForSeconds(user.animator.GetCurrentAnimatorStateInfo(0).length);
+                        //
+                        */
 
-        }
-        else
-            yield return dialogueBox.TypeDialougueText_CR($"{user.unitName}'s attack missed!");
+                        yield return animations.AnimateMoveUsage_CR(user, target, move);
+                        DamageDetails details = target.TakeMoveDamage(move, user);
 
-        yield return new WaitForSeconds(.75f);
-        move.LastUsedTurn = crntTurn;// change so charge moves count as last used after the charged turn
+                        target.animator.Play("BattleEnemy_Damaged2");
 
-    }
+                        yield return new WaitForSeconds(target.animator.GetCurrentAnimatorStateInfo(0).length);
 
+                        yield return target.BHud.WaitHpUpdat_CR();
 
 
-    IEnumerator OnMove(HitEffectsID effect, Unit user, int dmg)
-    {
-        yield return null;
-    }
-
-
-    IEnumerator AfterMove_CR(Unit user)
-    {
-        if (state == BattleState.END) yield break;
-        yield return new WaitUntil(() => state == BattleState.TURN_RESOLUTION);
-
-        user.CrrPokemon.AfterTurnEffects();
-
-        //animation
-
-        yield return user.BHud.WaitHpUpdat_CR();
-        yield return ShowEffectsChanges_CR(user);
-        //refactor
-        if (user.CrrPokemon.HP <= 0)
-        {
-            yield return Fainted_CR(user);
-        }
-    }
-
-    IEnumerator RunMoveEffects_CR(MoveEffects effects, Unit user, Unit enemy, Target effectTarget)
-    {
-
-        var target = (effectTarget == Target.Self) ? user : enemy;
-
-        if (effects.StatMods != null)
-            target.ApplyStatStage(effects.StatMods);
-
-        if (effects.Condition != ConditionID.none)
-            target.ApplyCondition(effects.Condition, user);
-
-
-        //play animations here animation
-
-
-
-        yield return ShowEffectsChanges_CR(user);
-        yield return ShowEffectsChanges_CR(enemy);
-
-    }
-
-    IEnumerator TryToEscape_CR(Unit escapee, Unit persuer)
-    {
-        if (isTrainerBattle)
-        {
-            yield return dialogueBox.TypeDialougueText_CR("Can't escape!");
-
-            yield break;
-        }
-
-        if (OddsOfEscape(escapee.GetStat(Stat.Speed), persuer.GetStat(Stat.Speed)))
-        {
-            if (escapee == playerUnit)
-                yield return dialogueBox.TypeDialougueText_CR("You got away safely!", 2.25f, persistAfterRead: true);
-            else
-                yield return dialogueBox.TypeDialougueText_CR($"{escapee.CrrPokemon.NickName} ran away!", 2.25f, persistAfterRead: true);
-
-            ChangeState(BattleState.END);//
-
-            yield return new WaitForSeconds(1f);
-            yield return GameManager.Instance.FadeInToFreeRoam_CR();
-            escapee.CrrPokemon.HasLeveledUp();
-
-            OnEndBattle(false);
-            yield break;
-        }
-
-        yield return dialogueBox.TypeDialougueText_CR("You couldn't get away!", 2.25f);
-
-
-    }
-
-    IEnumerator OnEndOfRound_CR()
-    {
-
-        //animation
-        yield return playerUnit.LeechSeedEffect_CR();
-        yield return ShowEffectsChanges_CR(playerUnit);
-
-        if (playerUnit.CrrPokemon.HP <= 0)
-        {
-            yield return Fainted_CR(playerUnit);
-        }
-        if (state == BattleState.END) yield break;
-
-        //animation
-        yield return enemyUnit.LeechSeedEffect_CR();
-        yield return ShowEffectsChanges_CR(enemyUnit);
-
-        if (enemyUnit.CrrPokemon.HP <= 0)
-        {
-            yield return Fainted_CR(enemyUnit);
-        }
-
-        if (state == BattleState.END) yield break;
-        yield return null;
-    }
-
-
-    IEnumerator ShowEffectsChanges_CR(Unit poke, float readTimeInSec = 1.5f)
-    {
-        while (poke.CrrPokemon.StatusChangeQuote.Count > 0)
-        {
-            var message = poke.CrrPokemon.StatusChangeQuote.Dequeue();
-            yield return dialogueBox.TypeDialougueText_CR(message, readTimeInSec);
-        }
-    }
-
-    bool MoveHitCheck(Move move, Unit user, Unit target)
-    {
-        if (move.Base.AlwaysHits)
-            return true;
-
-        //other hit conditions
-
-
-        float moveAccu = move.Base.Accuracy;
-
-        int accu = user.StatStages[Stat.Accuracy];
-        int evas = target.StatStages[Stat.Evasion];
-
-        int precision = Mathf.Clamp(accu - evas, -6, +6);
-
-        int hit = Mathf.FloorToInt(moveAccu * BoostTable.GetPrecision(precision));
-
-        return (UnityEngine.Random.Range(1, 101) <= hit);
-    }
-
-
-    bool OddsOfEscape(int escapee, int persuer)
-    {
-        ++fleeAtempts;
-        if (escapee < persuer)
-        {
-            int oddsBase = ((escapee * 128) / persuer) + 30 * fleeAtempts;
-
-            return (oddsBase % 256) > UnityEngine.Random.Range(0, 255);
-        }
-
-        return true;
-    }
-
-    IEnumerator ShowMoveDetails_CR(DamageDetails details)//show recoil and lifeLeech here too
-    {
-        if (details.Critical > 1f)
-            yield return dialogueBox.TypeDialougueText_CR("A critical hit!", 1.75f);
-
-        if (details.Effectiveness > 1f)
-            yield return dialogueBox.TypeDialougueText_CR("It's super effective!");
-
-        else if (details.Effectiveness < 1f)
-            yield return dialogueBox.TypeDialougueText_CR("It's not very effective.");
-
-        else if (details.Effectiveness <= 0f)
-            yield return dialogueBox.TypeDialougueText_CR("It doesn't affect...");
-
-    }
-
-    IEnumerator Fainted_CR(Unit fainted)
-    {
-
-        fainted.ApplyCondition(ConditionID.fnt);
-        // yield return dialogueBox.TypeDialougueText_CR($"{fainted.CrrPokemon.NickName} has fainted.", 2.5f);
-        yield return animations.FaintAnimation_CR(fainted);
-        fainted.BHud.gameObject.SetActive(false);
-        yield return ShowEffectsChanges_CR(fainted, 2);
-
-        if (!fainted.IsPlayerOrAlly)
-        {
-            int exp = fainted.Species.ExpYield;
-            int enemyLvl = fainted.CrrPokemon.Level;
-            float trainerBonus = (isTrainerBattle) ? 1.5f : 1f;
-            Pokemon crrtPkmn = playerUnit.CrrPokemon;
-
-
-            int expGain = Mathf.FloorToInt((trainerBonus * exp * enemyLvl) / 7);
-            if (crrtPkmn.Level < 100)
-            {
-                playerUnit.CrrPokemon.Exp += expGain;
-                yield return dialogueBox.TypeDialougueText_CR($"{playerUnit.CrrPokemon.NickName} gained {expGain} Exp. Points!");
-                yield return playerUnit.BHud.UpdateXp_CR();//redundent?
-            }
-
-            while (playerUnit.CrrPokemon.HasLeveledUp())
-            {
-                playerUnit.BHud.UpdateLevel();
-                yield return dialogueBox.TypeDialougueText_CR($"{playerUnit.CrrPokemon.NickName} grew to Lv. {playerUnit.CrrPokemon.Level}!");
-
-                //try to learn new move
-                var newMove = playerUnit.CrrPokemon.GetLearnableMoveAtLevel();
-                if (newMove != null)
-                {
-                    if (playerUnit.CrrPokemon.MoveSet.Count < PokemonBase.MAX_MOVES_COUNT)
-                    {
-                        playerUnit.CrrPokemon.LearnMove(newMove.BaseMove);
-                        yield return dialogueBox.TypeDialougueText_CR($"{playerUnit.CrrPokemon.NickName} learned  {newMove.BaseMove.name}!");
-                        dialogueBox.SetMoveButtons(playerUnit.CrrPokemon.MoveSet);
+                        dmg = details.Damage;
+                        yield return ShowMoveDetails_CR(details);
 
                     }
                     else
                     {
-
-                        yield return dialogueBox.TypeDialougueText_CR($"{playerUnit.CrrPokemon.NickName} is trying to learn {newMove.BaseMove.MoveName}");
-                        yield return dialogueBox.TypeDialougueText_CR($"But it cannot learn more than {PokemonBase.MAX_MOVES_COUNT} moves");
-                        yield return SelectMoveToForget_CR(playerUnit.CrrPokemon, newMove.BaseMove);
-
-                        yield return new WaitWhile(() => state == BattleState.FORGET_MOVE);
+                        //play charging animation?
+                        yield return dialogueBox.TypeDialougueText_CR($"{user.name} is charging a attack.");//make constumized for each move
                     }
                 }
 
-
-                yield return playerUnit.BHud.UpdateXp_CR(true);//redundent?
-
-            }
-
-        }
-
-        yield return CheckBattleResults_CR(fainted);
-        yield break;
-
-
-    }
-
-    IEnumerator SelectMoveToForget_CR(Pokemon poke, MovesBase newMove)
-    {
-        ChangeState(BattleState.FORGET_MOVE);
-        yield return dialogueBox.TypeDialougueText_CR($"Choose a move to forget", readTimeInSeconds: 2.5f);
-        // dialogueBox.SetCurrentActiveMenu(forgetMoveUI.gameObject, mode: MenuMode.Forget_Move);
-        dialogueBox.SetCurrentBattleScreen(forgetMoveUI,
-            () =>
-            {
-                dialogueBox.CloseMenus();
-
-                StartCoroutine(ForgetMove_CR(forgetMoveUI.SelectedIndex, newMove));
-
-            },
-            () =>
-            {
-                dialogueBox.CloseMenus();
-                StartCoroutine(ForgetMove_CR(PokemonBase.MAX_MOVES_COUNT, newMove));
-                //return false;
-            },
-            MenuMode.Forget_Move);
-
-        /*
-        Action<int> OnMoveSelection = (index) =>
-        {
-            
-            dialogueBox.CloseMenus();
-
-            StartCoroutine(ForgetMove(index, newMove));
-        };
-        */
-
-        forgetMoveUI.SetForgetMenu(poke, newMove);
-
-    }
-
-    IEnumerator ForgetMove_CR(int index, MovesBase newMove)
-    {
-        //dialogueBox.CloseMenus();
-        if (index == PokemonBase.MAX_MOVES_COUNT)
-        {
-            yield return dialogueBox.TypeDialougueText_CR($"{playerUnit.unitName} did not learn {newMove.MoveName}");
-        }
-        else
-        {
-
-            var selectedMove = playerUnit.CrrPokemon.MoveSet[index].Base;
-            yield return dialogueBox.TypeDialougueText_CR($"{playerUnit.unitName} forgot {selectedMove.MoveName} and learned {newMove.MoveName}");
-
-            playerUnit.CrrPokemon.MoveSet[index] = new Move(newMove);
-        }
-        ChangeState(BattleState.TURN_RESOLUTION);
-
-
-
-        yield return null;
-    }
-
-
-    IEnumerator CheckBattleResults_CR(Unit loser)//separate logic from display of results
-    {
-        bool hasWon;
-        if (loser == playerUnit)
-        {
-            var substitute = playerParty.GetHealthy();
-            if (substitute != null)
-            {
-                ChangeState(BattleState.SWITCHING);
-                //partyMenu.SetButtons(OnSelectFromParty, CancelButtonPartyMenu);
-                //dialogueBox.SetCurrentActiveMenu(partyMenu.gameObject, true, MenuMode.Party);
-                dialogueBox.SetCurrentBattleScreen(partyMenu, mode: MenuMode.Party, keepPrevious: true);
-
-
-                yield return new WaitUntil(() => state != BattleState.SWITCHING);
-                yield break;
-
-            }
-
-            //yield return dialogueBox.TypeDialougueText_CR($"You Were defeated.", 1.75f);
-            hasWon = false;
-
-        }
-        else
-        {
-            if (isTrainerBattle)
-            {
-                //var nextPoke = trainerTeam.GetHealthy();
-                var nextPoke = trainerParty.GetHealthy();
-                if (nextPoke != null)
+                var hitEffect = move.Base.EffectWhenHit;
+                if (hitEffect != HitEffectsID.none)
                 {
-                    yield return WhenTrainerSwitching_CR(nextPoke);
-                    yield return SwitchOpponentPokemon_CR(nextPoke);
+                    //TO DO: set this effect on takedamage method, without the need of capturing damage without method
+                    ConditionsDB.HitEffects[hitEffect].OnHit?.Invoke(user.CrrPokemon, dmg);
+
+                    //Animations
+
+                    yield return user.BHud.WaitHpUpdat_CR();
+                    var affectd = (hitEffect == HitEffectsID.leech_life) ? target : user;
+                    yield return dialogueBox.TypeDialougueText_CR($"{affectd.unitName}{ConditionsDB.HitEffects[hitEffect].Message}");
+
+                }
+                if (target.CrrPokemon.HP <= 0)
+                {
+                    yield return Fainted_CR(target);
+                    yield break;
+
+                }
+
+
+                if (user.CrrPokemon.HP <= 0)
+                {
+                    yield return Fainted_CR(user);
                     yield break;
                 }
 
-            }
 
-            // yield return dialogueBox.TypeDialougueText_CR($"Congratulations!!!",persistAfterRead: true);
-            hasWon = true;
-        }
-
-        yield return new WaitForSeconds(1f);
-
-        ChangeState(BattleState.END);
-        yield return ShowBattleResult_CR(hasWon);
-        yield return GameManager.Instance.FadeInToFreeRoam_CR();
-
-        OnEndBattle(hasWon);
-
-    }
-
-
-
-    IEnumerator ShowBattleResult_CR(bool hasWon = false)//for implementation
-    {
-        if (isTrainerBattle)
-        {
-            if (hasWon)
-                yield return dialogueBox.TypeDialougueText_CR($"Congratulations!!! You defeated {trainer.Name}!!", persistAfterRead: true);
-
-            else
-                yield return dialogueBox.TypeDialougueText_CR($"You Were defeated by {trainer.Name}.", 1.75f);
-
-        }
-
-    }
-
-
-    void OnEndBattle(bool result = false)
-    {
-        ChangeState(BattleState.END);
-        //put results here?
-        playerUnit.CrrPokemon.RemoveAllVolat();
-        playerUnit.RemoveSeeds();
-        enemyUnit.RemoveSeeds();
-        enemyUnit.ResetSprite();
-        if (trainerData != null)
-            trainerData.OnEndOfBattle(result);
-
-        battlesData.Won = result;
-        if (trainer != null)
-            trainer.GetBattleResult(result);
-
-        StopAllCoroutines();//does this prevent all stacked corputines to continue?
-        //Clear Battle data
-        //GameManager.Instance.EndBattleScene();
-
-        playerObject.SetActive(false);
-        enemyObject.SetActive(false);
-        GameManager.Instance.EndOfBattle();
-
-    }
-
-    IEnumerator SwitchOpponentPokemon_CR(Pokemon next)
-    {
-        yield return new WaitUntil(() => state != BattleState.SWITCHING);
-
-        enemyUnit.SetUpUnit(next);
-        yield return dialogueBox.TypeDialougueText_CR($"{trainer.Name} sent out a {next.NickName}.");
-        enemyUnit.unitName = "The foe's " + enemyUnit.unitName;
-
-        ChangeState(BattleState.TURN_RESOLUTION);
-    }
-
-
-
-
-    IEnumerator WhenTrainerSwitching_CR(Pokemon trainerNew)
-    {
-        yield return dialogueBox.TypeDialougueText_CR($"{trainer.Name} is about to send {trainerNew.NickName}. Do you want to change pokemon?");
-
-        //dialogueBox.SetQuestionToSwitch();
-        dialogueBox.SetCurrentActiveMenu(choiceDoSwitchMenu, mode: MenuMode.Confirmation, onReturn: ContinueBattleFromTrainerLost);
-        ChangeState(BattleState.SWITCHING);
-
-        //make call for trainer switch
-
-    }
-
-    //Buttons Fuctionalities
-    public void OnMoveButton()
-    {
-        if ((state != BattleState.DECISION_PHASE))
-            return;
-
-        dialogueBox.SetMovesMenu();
-
-    }
-
-
-    public void OnPartyButton()
-    {
-        if (state != BattleState.DECISION_PHASE && state != BattleState.SWITCHING)
-            return;
-
-        //partyMenu.SetSelectionAction(OnSelectFromParty);
-        // partyMenu.SetButtons(OnSelectFromParty, CancelButtonPartyMenu);
-        // dialogueBox.SetCurrentBattleScreen(partyMenu, OnSelectFromParty, CancelButtonPartyMenu, MenuMode.Party);
-        dialogueBox.SetCurrentBattleScreen(partyMenu, mode: MenuMode.Party);
-        //dialogueBox.SetCurrentActiveMenu(partyMenu.gameObject, mode: MenuMode.Party);
-    }
-
-    //OnBagSelection
-
-    public void OnBagSelection()
-    {
-        if (state != BattleState.DECISION_PHASE)
-            return;
-
-
-        dialogueBox.SetCurrentActiveMenu(inventoryPocketSelectionMenu, mode: MenuMode.Bag,
-            onReturn:
-            () =>
-            {
-                if (inventory && inventory.gameObject.activeSelf)
+                if (move.Base.Secundaries != null && move.Base.Secundaries.Count > 0)
                 {
-                    inventory.CancelButton();
-                    return;
+                    foreach (var secondary in move.Base.Secundaries) //(int i = 0; i < move.Base.Secundaries.Count; i++)
+                    {
+                        if (secondary.Condition == ConditionID.leech_seed)
+                            continue;
+
+                        if (UnityEngine.Random.Range(1, 101) <= secondary.StatusChance)
+                        {
+                            var doesHappenOnChargingTurn = ((move.isCharged && secondary.Target == Target.Foe) || (!move.isCharged && secondary.Target == Target.Self));
+                            if (!move.Base.HasChargingTurn || doesHappenOnChargingTurn)
+                                yield return RunMoveEffects_CR(secondary, user, target, secondary.Target);
+
+
+                            //play animations here? only one execution but need to check if there is no more then two diferente changes, like one up stat, one doen stat, one status change
+                        }
+                    }
                 }
 
-                dialogueBox.ReturnToActionMenu();
             }
-            );
+            else
+                yield return dialogueBox.TypeDialougueText_CR($"{user.unitName}'s attack missed!");
 
+            yield return new WaitForSeconds(.75f);
+            move.LastUsedTurn = crntTurn;// change so charge moves count as last used after the charged turn
 
-        //dialogueBox.CloseMenus();
-        //StartCoroutine(TurnResolution_CR(BattleAction.UseItem));
-
-        //open bag menu without the need for deactivate actionsmenu
-        //maybe use another scene
-    }
-
-
-    public void OnRunButton()
-    {
-        if (state != BattleState.DECISION_PHASE)
-            return;
-
-        dialogueBox.CloseMenus();
-        StartCoroutine(TurnResolution_CR(BattleAction.Run));
-    }
+        }
 
 
 
-
-
-
-    /// <summary>
-    /// Buttons of menus. 
-    /// </summary>
-
-
-    public void ContinueBattleFromTrainerLost()
-    {
-
-        dialogueBox.CloseMenus();
-        ChangeState(BattleState.FOE_SWITCHING);
-    }
-
-
-    public void ChooseMoveByButton(Button mButton)
-    {
-        if (state != BattleState.DECISION_PHASE)
-            return;
-
-        var movesRel = dialogueBox.ButtonMove;
-        if (movesRel.ContainsKey(mButton))
+        IEnumerator OnMove(HitEffectsID effect, Unit user, int dmg)
         {
-            if (movesRel[mButton].Pp >= 1)
+            yield return null;
+        }
+
+
+        IEnumerator AfterMove_CR(Unit user)
+        {
+            if (state == BattleState.END) yield break;
+            yield return new WaitUntil(() => state == BattleState.TURN_RESOLUTION);
+
+            user.CrrPokemon.AfterTurnEffects();
+
+            //animation
+
+            yield return user.BHud.WaitHpUpdat_CR();
+            yield return ShowEffectsChanges_CR(user);
+            //refactor
+            if (user.CrrPokemon.HP <= 0)
             {
-                playerUnit.MoveOfChoice = movesRel[mButton];
+                yield return Fainted_CR(user);
+            }
+        }
+
+        IEnumerator RunMoveEffects_CR(MoveEffects effects, Unit user, Unit enemy, Target effectTarget)
+        {
+
+            var target = (effectTarget == Target.Self) ? user : enemy;
+
+            if (effects.StatMods != null)
+                target.ApplyStatStage(effects.StatMods);
+
+            if (effects.Condition != ConditionID.none)
+                target.ApplyCondition(effects.Condition, user);
+
+
+            //play animations here animation
+
+
+
+            yield return ShowEffectsChanges_CR(user);
+            yield return ShowEffectsChanges_CR(enemy);
+
+        }
+
+        IEnumerator TryToEscape_CR(Unit escapee, Unit persuer)
+        {
+            if (isTrainerBattle)
+            {
+                yield return dialogueBox.TypeDialougueText_CR("Can't escape!");
+
+                yield break;
+            }
+
+            if (OddsOfEscape(escapee.GetStat(Stat.Speed), persuer.GetStat(Stat.Speed)))
+            {
+                if (escapee == playerUnit)
+                    yield return dialogueBox.TypeDialougueText_CR("You got away safely!", 2.25f, persistAfterRead: true);
+                else
+                    yield return dialogueBox.TypeDialougueText_CR($"{escapee.CrrPokemon.NickName} ran away!", 2.25f, persistAfterRead: true);
+
+                ChangeState(BattleState.END);//
+
+                yield return new WaitForSeconds(1f);
+                yield return GameManager.Instance.FadeInToFreeRoam_CR();
+                escapee.CrrPokemon.HasLeveledUp();
+
+                OnEndBattle(false);
+                yield break;
+            }
+
+            yield return dialogueBox.TypeDialougueText_CR("You couldn't get away!", 2.25f);
+
+
+        }
+
+        IEnumerator OnEndOfRound_CR()
+        {
+
+            //animation
+            yield return playerUnit.LeechSeedEffect_CR();
+            yield return ShowEffectsChanges_CR(playerUnit);
+
+            if (playerUnit.CrrPokemon.HP <= 0)
+            {
+                yield return Fainted_CR(playerUnit);
+            }
+            if (state == BattleState.END) yield break;
+
+            //animation
+            yield return enemyUnit.LeechSeedEffect_CR();
+            yield return ShowEffectsChanges_CR(enemyUnit);
+
+            if (enemyUnit.CrrPokemon.HP <= 0)
+            {
+                yield return Fainted_CR(enemyUnit);
+            }
+
+            if (state == BattleState.END) yield break;
+            yield return null;
+        }
+
+
+        IEnumerator ShowEffectsChanges_CR(Unit poke, float readTimeInSec = 1.5f)
+        {
+            while (poke.CrrPokemon.StatusChangeQuote.Count > 0)
+            {
+                var message = poke.CrrPokemon.StatusChangeQuote.Dequeue();
+                yield return dialogueBox.TypeDialougueText_CR(message, readTimeInSec);
+            }
+        }
+
+        bool MoveHitCheck(Move move, Unit user, Unit target)
+        {
+            if (move.Base.AlwaysHits)
+                return true;
+
+            //other hit conditions
+
+
+            float moveAccu = move.Base.Accuracy;
+
+            int accu = user.StatStages[Stat.Accuracy];
+            int evas = target.StatStages[Stat.Evasion];
+
+            int precision = Mathf.Clamp(accu - evas, -6, +6);
+
+            int hit = Mathf.FloorToInt(moveAccu * BoostTable.GetPrecision(precision));
+
+            return (UnityEngine.Random.Range(1, 101) <= hit);
+        }
+
+
+        bool OddsOfEscape(int escapee, int persuer)
+        {
+            ++fleeAtempts;
+            if (escapee < persuer)
+            {
+                int oddsBase = ((escapee * 128) / persuer) + 30 * fleeAtempts;
+
+                return (oddsBase % 256) > UnityEngine.Random.Range(0, 255);
+            }
+
+            return true;
+        }
+
+        IEnumerator ShowMoveDetails_CR(DamageDetails details)//show recoil and lifeLeech here too
+        {
+            if (details.Critical > 1f)
+                yield return dialogueBox.TypeDialougueText_CR("A critical hit!", 1.75f);
+
+            if (details.Effectiveness > 1f)
+                yield return dialogueBox.TypeDialougueText_CR("It's super effective!");
+
+            else if (details.Effectiveness < 1f)
+                yield return dialogueBox.TypeDialougueText_CR("It's not very effective.");
+
+            else if (details.Effectiveness <= 0f)
+                yield return dialogueBox.TypeDialougueText_CR("It doesn't affect...");
+
+        }
+
+        IEnumerator Fainted_CR(Unit fainted)
+        {
+
+            fainted.ApplyCondition(ConditionID.fnt);
+            // yield return dialogueBox.TypeDialougueText_CR($"{fainted.CrrPokemon.NickName} has fainted.", 2.5f);
+            yield return animations.FaintAnimation_CR(fainted);
+            fainted.BHud.gameObject.SetActive(false);
+            yield return ShowEffectsChanges_CR(fainted, 2);
+
+            if (!fainted.IsPlayerOrAlly)
+            {
+                int exp = fainted.Species.ExpYield;
+                int enemyLvl = fainted.CrrPokemon.Level;
+                float trainerBonus = (isTrainerBattle) ? 1.5f : 1f;
+                Pokemon crrtPkmn = playerUnit.CrrPokemon;
+
+
+                int expGain = Mathf.FloorToInt((trainerBonus * exp * enemyLvl) / 7);
+                if (crrtPkmn.Level < 100)
+                {
+                    playerUnit.CrrPokemon.Exp += expGain;
+                    yield return dialogueBox.TypeDialougueText_CR($"{playerUnit.CrrPokemon.NickName} gained {expGain} Exp. Points!");
+                    yield return playerUnit.BHud.UpdateXp_CR();//redundent?
+                }
+
+                while (playerUnit.CrrPokemon.HasLeveledUp())
+                {
+                    playerUnit.BHud.UpdateLevel();
+                    yield return dialogueBox.TypeDialougueText_CR($"{playerUnit.CrrPokemon.NickName} grew to Lv. {playerUnit.CrrPokemon.Level}!");
+
+                    //try to learn new move
+                    var newMove = playerUnit.CrrPokemon.GetLearnableMoveAtLevel();
+                    if (newMove != null)
+                    {
+                        if (playerUnit.CrrPokemon.MoveSet.Count < PokemonBase.MAX_MOVES_COUNT)
+                        {
+                            playerUnit.CrrPokemon.LearnMove(newMove.BaseMove);
+                            yield return dialogueBox.TypeDialougueText_CR($"{playerUnit.CrrPokemon.NickName} learned  {newMove.BaseMove.name}!");
+                            dialogueBox.SetMoveButtons(playerUnit.CrrPokemon.MoveSet);
+
+                        }
+                        else
+                        {
+
+                            yield return dialogueBox.TypeDialougueText_CR($"{playerUnit.CrrPokemon.NickName} is trying to learn {newMove.BaseMove.MoveName}");
+                            yield return dialogueBox.TypeDialougueText_CR($"But it cannot learn more than {PokemonBase.MAX_MOVES_COUNT} moves");
+                            yield return SelectMoveToForget_CR(playerUnit.CrrPokemon, newMove.BaseMove);
+
+                            yield return new WaitWhile(() => state == BattleState.FORGET_MOVE);
+                        }
+                    }
+
+
+                    yield return playerUnit.BHud.UpdateXp_CR(true);//redundent?
+
+                }
+
+            }
+
+            yield return CheckBattleResults_CR(fainted);
+            yield break;
+
+
+        }
+
+        IEnumerator SelectMoveToForget_CR(Pokemon poke, MovesBase newMove)
+        {
+            ChangeState(BattleState.FORGET_MOVE);
+            yield return dialogueBox.TypeDialougueText_CR($"Choose a move to forget", readTimeInSeconds: 2.5f);
+            // dialogueBox.SetCurrentActiveMenu(forgetMoveUI.gameObject, mode: MenuMode.Forget_Move);
+            dialogueBox.SetCurrentBattleScreen(forgetMoveUI,
+                () =>
+                {
+                    dialogueBox.CloseMenus();
+
+                    StartCoroutine(ForgetMove_CR(forgetMoveUI.SelectedIndex, newMove));
+
+                },
+                () =>
+                {
+                    dialogueBox.CloseMenus();
+                    StartCoroutine(ForgetMove_CR(PokemonBase.MAX_MOVES_COUNT, newMove));
+                //return false;
+            },
+                MenuMode.Forget_Move);
+
+            /*
+            Action<int> OnMoveSelection = (index) =>
+            {
+
+                dialogueBox.CloseMenus();
+
+                StartCoroutine(ForgetMove(index, newMove));
+            };
+            */
+
+            forgetMoveUI.SetForgetMenu(poke, newMove);
+
+        }
+
+        IEnumerator ForgetMove_CR(int index, MovesBase newMove)
+        {
+            //dialogueBox.CloseMenus();
+            if (index == PokemonBase.MAX_MOVES_COUNT)
+            {
+                yield return dialogueBox.TypeDialougueText_CR($"{playerUnit.unitName} did not learn {newMove.MoveName}");
+            }
+            else
+            {
+
+                var selectedMove = playerUnit.CrrPokemon.MoveSet[index].Base;
+                yield return dialogueBox.TypeDialougueText_CR($"{playerUnit.unitName} forgot {selectedMove.MoveName} and learned {newMove.MoveName}");
+
+                playerUnit.CrrPokemon.MoveSet[index] = new Move(newMove);
+            }
+            ChangeState(BattleState.TURN_RESOLUTION);
+
+
+
+            yield return null;
+        }
+
+
+        IEnumerator CheckBattleResults_CR(Unit loser)//separate logic from display of results
+        {
+            bool hasWon;
+            if (loser == playerUnit)
+            {
+                var substitute = playerParty.GetHealthy();
+                if (substitute != null)
+                {
+                    ChangeState(BattleState.SWITCHING);
+                    //partyMenu.SetButtons(OnSelectFromParty, CancelButtonPartyMenu);
+                    //dialogueBox.SetCurrentActiveMenu(partyMenu.gameObject, true, MenuMode.Party);
+                    dialogueBox.SetCurrentBattleScreen(partyMenu, mode: MenuMode.Party, keepPrevious: true);
+
+
+                    yield return new WaitUntil(() => state != BattleState.SWITCHING);
+                    yield break;
+
+                }
+
+                //yield return dialogueBox.TypeDialougueText_CR($"You Were defeated.", 1.75f);
+                hasWon = false;
+
+            }
+            else
+            {
+                if (isTrainerBattle)
+                {
+                    //var nextPoke = trainerTeam.GetHealthy();
+                    var nextPoke = trainerParty.GetHealthy();
+                    if (nextPoke != null)
+                    {
+                        yield return WhenTrainerSwitching_CR(nextPoke);
+                        yield return SwitchOpponentPokemon_CR(nextPoke);
+                        yield break;
+                    }
+
+                }
+
+                // yield return dialogueBox.TypeDialougueText_CR($"Congratulations!!!",persistAfterRead: true);
+                hasWon = true;
+            }
+
+            yield return new WaitForSeconds(1f);
+
+            ChangeState(BattleState.END);
+            yield return ShowBattleResult_CR(hasWon);
+            yield return GameManager.Instance.FadeInToFreeRoam_CR();
+
+            OnEndBattle(hasWon);
+
+        }
+
+
+
+        IEnumerator ShowBattleResult_CR(bool hasWon = false)//for implementation
+        {
+            if (isTrainerBattle)
+            {
+                if (hasWon)
+                    yield return dialogueBox.TypeDialougueText_CR($"Congratulations!!! You defeated {trainer.Name}!!", persistAfterRead: true);
+
+                else
+                    yield return dialogueBox.TypeDialougueText_CR($"You Were defeated by {trainer.Name}.", 1.75f);
+
+            }
+
+        }
+
+
+        void OnEndBattle(bool result = false)
+        {
+            ChangeState(BattleState.END);
+            //put results here?
+            playerUnit.CrrPokemon.RemoveAllVolat();
+            playerUnit.RemoveSeeds();
+            enemyUnit.RemoveSeeds();
+            enemyUnit.ResetSprite();
+            if (trainerData != null)
+                trainerData.OnEndOfBattle(result);
+
+            battlesData.Won = result;
+            if (trainer != null)
+                trainer.GetBattleResult(result);
+
+            StopAllCoroutines();//does this prevent all stacked corputines to continue?
+                                //Clear Battle data
+                                //GameManager.Instance.EndBattleScene();
+
+            playerObject.SetActive(false);
+            enemyObject.SetActive(false);
+            GameManager.Instance.EndOfBattle();
+
+        }
+
+        IEnumerator SwitchOpponentPokemon_CR(Pokemon next)
+        {
+            yield return new WaitUntil(() => state != BattleState.SWITCHING);
+
+            enemyUnit.SetUpUnit(next);
+            yield return dialogueBox.TypeDialougueText_CR($"{trainer.Name} sent out a {next.NickName}.");
+            enemyUnit.unitName = "The foe's " + enemyUnit.unitName;
+
+            ChangeState(BattleState.TURN_RESOLUTION);
+        }
+
+
+
+
+        IEnumerator WhenTrainerSwitching_CR(Pokemon trainerNew)
+        {
+            yield return dialogueBox.TypeDialougueText_CR($"{trainer.Name} is about to send {trainerNew.NickName}. Do you want to change pokemon?");
+
+            //dialogueBox.SetQuestionToSwitch();
+            dialogueBox.SetCurrentActiveMenu(choiceDoSwitchMenu, mode: MenuMode.Confirmation, onReturn: ContinueBattleFromTrainerLost);
+            ChangeState(BattleState.SWITCHING);
+
+            //make call for trainer switch
+
+        }
+
+        //Buttons Fuctionalities
+        public void OnMoveButton()
+        {
+            if ((state != BattleState.DECISION_PHASE))
+                return;
+
+            dialogueBox.SetMovesMenu();
+
+        }
+
+
+        public void OnPartyButton()
+        {
+            if (state != BattleState.DECISION_PHASE && state != BattleState.SWITCHING)
+                return;
+
+            //partyMenu.SetSelectionAction(OnSelectFromParty);
+            // partyMenu.SetButtons(OnSelectFromParty, CancelButtonPartyMenu);
+            // dialogueBox.SetCurrentBattleScreen(partyMenu, OnSelectFromParty, CancelButtonPartyMenu, MenuMode.Party);
+            dialogueBox.SetCurrentBattleScreen(partyMenu, mode: MenuMode.Party);
+            //dialogueBox.SetCurrentActiveMenu(partyMenu.gameObject, mode: MenuMode.Party);
+        }
+
+        //OnBagSelection
+
+        public void OnBagSelection()
+        {
+            if (state != BattleState.DECISION_PHASE)
+                return;
+
+
+            dialogueBox.SetCurrentActiveMenu(inventoryPocketSelectionMenu, mode: MenuMode.Bag,
+                onReturn:
+                () =>
+                {
+                    if (inventory && inventory.gameObject.activeSelf)
+                    {
+                        inventory.CancelButton();
+                        return;
+                    }
+
+                    dialogueBox.ReturnToActionMenu();
+                }
+                );
+
+
+            //dialogueBox.CloseMenus();
+            //StartCoroutine(TurnResolution_CR(BattleAction.UseItem));
+
+            //open bag menu without the need for deactivate actionsmenu
+            //maybe use another scene
+        }
+
+
+        public void OnRunButton()
+        {
+            if (state != BattleState.DECISION_PHASE)
+                return;
+
+            dialogueBox.CloseMenus();
+            StartCoroutine(TurnResolution_CR(BattleAction.Run));
+        }
+
+
+
+
+
+
+        /// <summary>
+        /// Buttons of menus. 
+        /// </summary>
+
+
+        public void ContinueBattleFromTrainerLost()
+        {
+
+            dialogueBox.CloseMenus();
+            ChangeState(BattleState.FOE_SWITCHING);
+        }
+
+
+        public void ChooseMoveByButton(Button mButton)
+        {
+            if (state != BattleState.DECISION_PHASE)
+                return;
+
+            var movesRel = dialogueBox.ButtonMove;
+            if (movesRel.ContainsKey(mButton))
+            {
+                if (movesRel[mButton].Pp >= 1)
+                {
+                    playerUnit.MoveOfChoice = movesRel[mButton];
+                    if (playerUnit.MoveOfChoice.Base.HasChargingTurn)
+                        playerUnit.MoveOfChoice.isCharged = false;
+                    animations.SetMoveAnimation(playerUnit.MoveOfChoice, playerUnit);
+                    dialogueBox.CloseMenus();
+                    StartCoroutine(TurnResolution_CR(BattleAction.Moves));
+                }
+            }
+        }
+
+
+        public void ChooseMoveByIndex()
+        {
+            if (state != BattleState.DECISION_PHASE)
+                return;
+
+            var move = playerUnit.CrrPokemon.MoveSet[EventSystem.current.currentSelectedGameObject.transform.GetSiblingIndex()];
+
+            if (move.Pp >= 1)
+            {
+                playerUnit.MoveOfChoice = move;
                 if (playerUnit.MoveOfChoice.Base.HasChargingTurn)
                     playerUnit.MoveOfChoice.isCharged = false;
                 animations.SetMoveAnimation(playerUnit.MoveOfChoice, playerUnit);
                 dialogueBox.CloseMenus();
                 StartCoroutine(TurnResolution_CR(BattleAction.Moves));
+
             }
         }
-    }
 
-
-    public void ChooseMoveByIndex()
-    {
-        if (state != BattleState.DECISION_PHASE)
-            return;
-
-        var move = playerUnit.CrrPokemon.MoveSet[EventSystem.current.currentSelectedGameObject.transform.GetSiblingIndex()];
-
-        if (move.Pp >= 1)
+        public void OnSelectFromParty()
         {
-            playerUnit.MoveOfChoice = move;
-            if (playerUnit.MoveOfChoice.Base.HasChargingTurn)
-                playerUnit.MoveOfChoice.isCharged = false;
-            animations.SetMoveAnimation(playerUnit.MoveOfChoice, playerUnit);
+            if (partyMenu.SelectedPokemon.HP <= 0 || partyMenu.SelectedPokemon == null || playerUnit.CrrPokemon == partyMenu.SelectedPokemon)
+                return;
+
+            //dialogueBox.subMenu = SubMenu.Confirmation;
+            if (partyMenu.BattleConfirmMenu != null)
+            {
+                dialogueBox.SetCurrentActiveMenu(partyMenu.BattleConfirmMenu, true);
+                return;
+            }
+            dialogueBox.SetCurrentActiveMenu(partyMenu.ConfirmMenu, true);
+
+        }
+
+        public void SwitchButton()
+        {
+            if (state != BattleState.SWITCHING && state != BattleState.DECISION_PHASE && partyMenu.SelectedPokemon == null)
+                return;
+
+            if (partyMenu.SelectedPokemon.HP <= 0)
+                return;
+
             dialogueBox.CloseMenus();
-            StartCoroutine(TurnResolution_CR(BattleAction.Moves));
+            if (state == BattleState.SWITCHING)
+            {
+                StartCoroutine(SwitchPokemonUnit_CR(partyMenu.SelectedPokemon));//change to decision phase
 
+                return;
+            }
+            StartCoroutine(TurnResolution_CR(BattleAction.Switch));
         }
-    }
 
-    public void OnSelectFromParty()
-    {
-        if (partyMenu.SelectedPokemon.HP <= 0 || partyMenu.SelectedPokemon == null || playerUnit.CrrPokemon == partyMenu.SelectedPokemon)
-            return;
-
-        //dialogueBox.subMenu = SubMenu.Confirmation;
-        if (partyMenu.BattleConfirmMenu != null)
+        public void CancelButtonPartyMenu()
         {
-            dialogueBox.SetCurrentActiveMenu(partyMenu.BattleConfirmMenu, true);
-            return;
-        }
-        dialogueBox.SetCurrentActiveMenu(partyMenu.ConfirmMenu, true);
+            if (playerUnit.CrrPokemon.HP <= 0)
+                return;
 
-    }
-
-    public void SwitchButton()
-    {
-        if (state != BattleState.SWITCHING && state != BattleState.DECISION_PHASE && partyMenu.SelectedPokemon == null)
-            return;
-
-        if (partyMenu.SelectedPokemon.HP <= 0)
-            return;
-
-        dialogueBox.CloseMenus();
-        if (state == BattleState.SWITCHING)
-        {
-            StartCoroutine(SwitchPokemonUnit_CR(partyMenu.SelectedPokemon));//change to decision phase
-
-            return;
-        }
-        StartCoroutine(TurnResolution_CR(BattleAction.Switch));
-    }
-
-    public void CancelButtonPartyMenu()
-    {
-        if (playerUnit.CrrPokemon.HP <= 0)
-            return;
-
-        if (state == BattleState.DECISION_PHASE)
-        {
-
-            dialogueBox.ReturnToActionMenu();
-            return;
-        }
-
-        ContinueBattleFromTrainerLost();
-        // return false;
-    }
-
-    public void BagSelectionButton()
-    {
-        int tabSelected = EventSystem.current.currentSelectedGameObject.transform.GetSiblingIndex();
-        //Debug.Log(tabSelected);
-        inventoryPocketSelectionMenu.SetActive(false);
-        inventory.Open(
-            () =>
+            if (state == BattleState.DECISION_PHASE)
             {
 
-                if (inventory.CheckIfPkball())
-                {
-                    StartCoroutine(UseItem_CR());
-                    return;
-                }
+                dialogueBox.ReturnToActionMenu();
+                return;
+            }
 
-                inventory.CrrntItemListEnabaler(false);
-                inventory.PartyMenuSelection.Open(
-                    () =>
+            ContinueBattleFromTrainerLost();
+            // return false;
+        }
+
+        public void BagSelectionButton()
+        {
+            int tabSelected = EventSystem.current.currentSelectedGameObject.transform.GetSiblingIndex();
+            //Debug.Log(tabSelected);
+            inventoryPocketSelectionMenu.SetActive(false);
+            inventory.Open(
+                () =>
+                {
+
+                    if (inventory.CheckIfPkball())
                     {
+                        StartCoroutine(UseItem_CR());
+                        return;
+                    }
+
+                    inventory.CrrntItemListEnabaler(false);
+                    inventory.PartyMenuSelection.Open(
+                        () =>
+                        {
                         //check if pp restore
                         StartCoroutine(UseItem_CR());
-                    }
-                    );
-            }
-            ,
-            () =>
-            {
-                inventory.gameObject.SetActive(false);
+                        }
+                        );
+                }
+                ,
+                () =>
+                {
+                    inventory.gameObject.SetActive(false);
 
 
-                inventoryPocketSelectionMenu.SetActive(true);
-                EventSystem.current.SetSelectedGameObject(inventoryPocketSelectionMenu.GetComponentInChildren<Button>().gameObject);
-                return;
+                    inventoryPocketSelectionMenu.SetActive(true);
+                    EventSystem.current.SetSelectedGameObject(inventoryPocketSelectionMenu.GetComponentInChildren<Button>().gameObject);
+                    return;
 
                 //inventoryPocketSelectionMenu.SetActive(true);
                 //EventSystem.current.SetSelectedGameObject(inventoryPocketSelectionMenu.GetComponentInChildren<Button>().gameObject);
                 //return;
             },
-            tabSelected);
-
-    }
-
-
-
-    IEnumerator UseItem_CR()
-    {
-
-
-        var itemUsed = inventory.UseItem_OnBattle();
-
-        if (!itemUsed)
-        {
-
-            yield return inventory.UnusableWarnning_CR();
-            yield break;
-        }
-        dialogueBox.CloseMenus();
-
-        //play animations for med itens etc
-        if (inventory.CheckIfPkball())
-        {
-            //inventory.gameObject.SetActive(false);
-            yield return ThrowPokeBall_CR(itemUsed as PokeBallItem);
+                tabSelected);
 
         }
-        else
+
+
+
+        IEnumerator UseItem_CR()
         {
-            inventory.PartyMenuSelection.gameObject.SetActive(false);
-            inventory.CrrntItemListEnabaler(true);
-            inventory.gameObject.SetActive(false);
-            //play Animation
-            yield return playerHUD.WaitHpUpdat_CR();
-            yield return dialogueBox.TypeDialougueText_CR($"Used {itemUsed.name} on {inventory.PartyMenuSelection.SelectedPokemon.NickName}.");
-        }
 
 
-        StartCoroutine(TurnResolution_CR(BattleAction.UseItem));
+            var itemUsed = inventory.UseItem_OnBattle();
 
-    }
-
-
-    IEnumerator ThrowPokeBall_CR(PokeBallItem pkball)// link to use pkball
-    {
-
-        if (isTrainerBattle)
-        {
-            yield return dialogueBox.TypeDialougueText_CR("You can't steal another trainer Pokemon!");
-            ChangeState(BattleState.TURN_RESOLUTION);
-            yield break;
-        }
-
-
-        ChangeState(BattleState.CATCHING);
-        yield return dialogueBox.TypeDialougueText_CR($"{playerParty.TrainerName} used a {pkball.Name.ToUpper()}.");
-        var ball = Instantiate(pokeBall, transform);
-        var ballAni = ball.GetComponent<Animator>();
-        yield return null;
-        yield return new WaitForSeconds(ballAni.GetCurrentAnimatorStateInfo(0).length);
-        //var ballAni = ;
-        //Debug.Log(ballAni.runtimeAnimatorController.name);
-
-
-        yield return animations.PlayThrowAnimation_CR(ballAni, enemyUnit);
-        int shakeCount = TryToCatch(enemyUnit.CrrPokemon, pkball);
-
-
-        Debug.Log("Shake count: " + shakeCount);
-        for (int i = 0; i < Mathf.Min(shakeCount, 3); i++)
-        {
-            Debug.Log("Cycle " + i);
-            yield return new WaitForSeconds(.5f);
-            yield return animations.PlayShakeAnimation_CR(ballAni);
-        }
-
-        if (shakeCount == 4)
-        {
-            yield return animations.PlayCatchSuccess_CR(ballAni);
-            yield return dialogueBox.TypeDialougueText_CR($"{enemyUnit.CrrPokemon.Species} was caught!");
-            //add pokemmon to party or PC
-            if (playerParty.GetSize() < 6)
+            if (!itemUsed)
             {
-                playerParty.AddToParty(enemyUnit.CrrPokemon);
-                yield return dialogueBox.TypeDialougueText_CR($"{enemyUnit.CrrPokemon.Species} has been added to the party.");
+
+                yield return inventory.UnusableWarnning_CR();
+                yield break;
+            }
+            dialogueBox.CloseMenus();
+
+            //play animations for med itens etc
+            if (inventory.CheckIfPkball())
+            {
+                //inventory.gameObject.SetActive(false);
+                yield return ThrowPokeBall_CR(itemUsed as PokeBallItem);
 
             }
-            //else adds to PC
-
-            Destroy(ball);
-            yield return new WaitForSeconds(1f);
-            yield return GameManager.Instance.FadeInToFreeRoam_CR();
-            OnEndBattle(true);
-
-        }
-        else
-        {
-            yield return new WaitForSeconds(1f);
-            yield return animations.PlayCatchFail_CR(ballAni, enemyUnit);
-
-            if (shakeCount == 0)
-                yield return dialogueBox.TypeDialougueText_CR($"Oh, no! The Pokémon broke free!");
-            else if (shakeCount == 1)
-                yield return dialogueBox.TypeDialougueText_CR($"Aww! It appeared to be caught!");
-            else if (shakeCount == 2)
-                yield return dialogueBox.TypeDialougueText_CR($"Aargh! Almost had it!");
             else
-                yield return dialogueBox.TypeDialougueText_CR($"Shoot! It was so close, too!");
+            {
+                inventory.PartyMenuSelection.gameObject.SetActive(false);
+                inventory.CrrntItemListEnabaler(true);
+                inventory.gameObject.SetActive(false);
+                //play Animation
+                yield return playerHUD.WaitHpUpdat_CR();
+                yield return dialogueBox.TypeDialougueText_CR($"Used {itemUsed.name} on {inventory.PartyMenuSelection.SelectedPokemon.NickName}.");
+            }
 
-            Destroy(ball);
-            ChangeState(BattleState.TURN_RESOLUTION);
+
+            StartCoroutine(TurnResolution_CR(BattleAction.UseItem));
+
         }
 
-    }
 
-
-    int TryToCatch(Pokemon pke, PokeBallItem ball)
-    {
-        float a = (3 * pke.MaxHP - 2 * pke.HP) * pke.Base.CatchRate * ball.GetCatchRateMod(pke) * ConditionsDB.GetCatchRateMod(pke.Status) / (3 * pke.MaxHP);
-
-        if (a >= byte.MaxValue)
-            return 4;
-
-        float b = 1048560 / Mathf.Sqrt(Mathf.Sqrt(16711680 / a));
-
-        int shakeCount = 0;
-        while (shakeCount < 4)
+        IEnumerator ThrowPokeBall_CR(PokeBallItem pkball)// link to use pkball
         {
-            if (UnityEngine.Random.Range(0, 65535) >= b)
-                break;
 
-            ++shakeCount;
+            if (isTrainerBattle)
+            {
+                yield return dialogueBox.TypeDialougueText_CR("You can't steal another trainer Pokemon!");
+                ChangeState(BattleState.TURN_RESOLUTION);
+                yield break;
+            }
+
+
+            ChangeState(BattleState.CATCHING);
+            yield return dialogueBox.TypeDialougueText_CR($"{playerParty.TrainerName} used a {pkball.Name.ToUpper()}.");
+            var ball = Instantiate(pokeBall, transform);
+            var ballAni = ball.GetComponent<Animator>();
+            yield return null;
+            yield return new WaitForSeconds(ballAni.GetCurrentAnimatorStateInfo(0).length);
+            //var ballAni = ;
+            //Debug.Log(ballAni.runtimeAnimatorController.name);
+
+
+            yield return animations.PlayThrowAnimation_CR(ballAni, enemyUnit);
+            int shakeCount = TryToCatch(enemyUnit.CrrPokemon, pkball);
+
+
+            Debug.Log("Shake count: " + shakeCount);
+            for (int i = 0; i < Mathf.Min(shakeCount, 3); i++)
+            {
+                Debug.Log("Cycle " + i);
+                yield return new WaitForSeconds(.5f);
+                yield return animations.PlayShakeAnimation_CR(ballAni);
+            }
+
+            if (shakeCount == 4)
+            {
+                yield return animations.PlayCatchSuccess_CR(ballAni);
+                yield return dialogueBox.TypeDialougueText_CR($"{enemyUnit.CrrPokemon.Species} was caught!");
+                //add pokemmon to party or PC
+                if (playerParty.GetSize() < 6)
+                {
+                    playerParty.AddToParty(enemyUnit.CrrPokemon);
+                    yield return dialogueBox.TypeDialougueText_CR($"{enemyUnit.CrrPokemon.Species} has been added to the party.");
+
+                }
+                //else adds to PC
+
+                Destroy(ball);
+                yield return new WaitForSeconds(1f);
+                yield return GameManager.Instance.FadeInToFreeRoam_CR();
+                OnEndBattle(true);
+
+            }
+            else
+            {
+                yield return new WaitForSeconds(1f);
+                yield return animations.PlayCatchFail_CR(ballAni, enemyUnit);
+
+                if (shakeCount == 0)
+                    yield return dialogueBox.TypeDialougueText_CR($"Oh, no! The Pokémon broke free!");
+                else if (shakeCount == 1)
+                    yield return dialogueBox.TypeDialougueText_CR($"Aww! It appeared to be caught!");
+                else if (shakeCount == 2)
+                    yield return dialogueBox.TypeDialougueText_CR($"Aargh! Almost had it!");
+                else
+                    yield return dialogueBox.TypeDialougueText_CR($"Shoot! It was so close, too!");
+
+                Destroy(ball);
+                ChangeState(BattleState.TURN_RESOLUTION);
+            }
+
         }
-        return shakeCount;
+
+
+        int TryToCatch(Pokemon pke, PokeBallItem ball)
+        {
+            float a = (3 * pke.MaxHP - 2 * pke.HP) * pke.Base.CatchRate * ball.GetCatchRateMod(pke) * ConditionsDB.GetCatchRateMod(pke.Status) / (3 * pke.MaxHP);
+
+            if (a >= byte.MaxValue)
+                return 4;
+
+            float b = 1048560 / Mathf.Sqrt(Mathf.Sqrt(16711680 / a));
+
+            int shakeCount = 0;
+            while (shakeCount < 4)
+            {
+                if (UnityEngine.Random.Range(0, 65535) >= b)
+                    break;
+
+                ++shakeCount;
+            }
+            return shakeCount;
+        }
+
+
+
     }
-
-
 
 }

--- a/Battle/BattleSystem.cs
+++ b/Battle/BattleSystem.cs
@@ -206,6 +206,7 @@ namespace pokeCopy
             playerObject.SetActive(true);
             playerUnit = playerObject.GetComponent<Unit>();
             playerUnit.SetUpUnit(playerParty.GetHealthy(), playerHUD);
+            playerUnit.CrrPokemon.DoesLevelUp = false;
 
             yield return new WaitForSeconds(1.5f);
 
@@ -372,6 +373,8 @@ namespace pokeCopy
 
         IEnumerator UseMove_CR(Unit user, Unit target, Move move)
         {
+            dialogueBox.SetText("");
+
             bool canMove = user.CrrPokemon.BeforeTurnEffects();
             //play before effect animation
             if (!canMove)
@@ -577,7 +580,6 @@ namespace pokeCopy
 
                 yield return new WaitForSeconds(1f);
                 yield return GameManager.Instance.FadeInToFreeRoam_CR();
-                escapee.CrrPokemon.HasLeveledUp();
 
                 OnEndBattle(false);
                 yield break;
@@ -698,7 +700,7 @@ namespace pokeCopy
                     yield return dialogueBox.TypeDialougueText_CR($"{playerUnit.CrrPokemon.NickName} gained {expGain} Exp. Points!");
                     yield return playerUnit.BHud.UpdateXp_CR();//redundent?
                 }
-
+                //playerUnit.CrrPokemon.HasLeveledUp1 = false;
                 while (playerUnit.CrrPokemon.HasLeveledUp())
                 {
                     playerUnit.BHud.UpdateLevel();

--- a/Battle/DialogueBox.cs
+++ b/Battle/DialogueBox.cs
@@ -7,285 +7,290 @@ using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.UI;
 using System;
 
-public class DialogueBox : MonoBehaviour //Refator needed. Better integration with battle system ekm menus. Redesign Architecture
+
+namespace pokeCopy
 {
 
-    /* Needs Clean Up of cancel action. Use A Delegate instead of if steatments 
-     * and configure in a way that there would be the nedd to contantly keep 
-     * track o current and previus open windows
-     */
-
-    [SerializeField] Text dialogueText;
-    [SerializeField] EventSystem buttonController;
-
-    [SerializeField] GameObject ActionMenu;
-    [SerializeField] GameObject MovesMenu;
-    [SerializeField] GameObject ChoiceButtons;
-    [SerializeField] Text moveTypeText;
-    [SerializeField] Text ppText;
-    [SerializeField] GameObject currentActiveMenu;
-    GameObject previousActive;
-    GameObject previousSelection;
-    [SerializeField] InputSystemUIInputModule input;
-    //[SerializeField] PartyMenu partySelection;
-
-    [SerializeField] Button[] moveButtuns;//can be by gameobject too
-    public Dictionary<Button, Move> ButtonMove { get; private set; }//decouple this from the dialog system so it limits its funtions to dialogue only
-
-    const float DEFAULT_READ_TIME = 1.25f;
-    const float DEFAULT_TYPE_DELAY = 0.0175f;
-
-    public MenuMode menuMode;//revise
-    public SubMenu subMenu;
-
-    Action OnCancelInput;
-
-
-    private void Awake()
+    public class DialogueBox : MonoBehaviour //Refator needed. Better integration with battle system ekm menus. Redesign Architecture
     {
-        buttonController = EventSystem.current;
-        input = EventSystem.current.GetComponent<InputSystemUIInputModule>();
-    }
 
-    public void SetText(string dialog)
-    {
-        dialogueText.text = dialog;
-    }
+        /* Needs Clean Up of cancel action. Use A Delegate instead of if steatments 
+         * and configure in a way that there would be the nedd to contantly keep 
+         * track o current and previus open windows
+         */
 
-    public IEnumerator TypeDialougueText_CR(string dialogue, float readTimeInSeconds = DEFAULT_READ_TIME, bool persistAfterRead = false, bool keepPrev = false, float typingDelayInSeconds = DEFAULT_TYPE_DELAY)
-    {
-        if (!keepPrev)
-            dialogueText.text = "";
+        [SerializeField] Text dialogueText;
+        [SerializeField] EventSystem buttonController;
 
-        foreach (char letter in dialogue.ToCharArray())
+        [SerializeField] GameObject ActionMenu;
+        [SerializeField] GameObject MovesMenu;
+        [SerializeField] GameObject ChoiceButtons;
+        [SerializeField] Text moveTypeText;
+        [SerializeField] Text ppText;
+        [SerializeField] GameObject currentActiveMenu;
+        GameObject previousActive;
+        GameObject previousSelection;
+        [SerializeField] InputSystemUIInputModule input;
+        //[SerializeField] PartyMenu partySelection;
+
+        [SerializeField] Button[] moveButtuns;//can be by gameobject too
+        public Dictionary<Button, Move> ButtonMove { get; private set; }//decouple this from the dialog system so it limits its funtions to dialogue only
+
+        const float DEFAULT_READ_TIME = 1.25f;
+        const float DEFAULT_TYPE_DELAY = 0.0175f;
+
+        public MenuMode menuMode;//revise
+        public SubMenu subMenu;
+
+        Action OnCancelInput;
+
+
+        private void Awake()
         {
-            dialogueText.text += letter;
-            yield return new WaitForSeconds(typingDelayInSeconds);
+            buttonController = EventSystem.current;
+            input = EventSystem.current.GetComponent<InputSystemUIInputModule>();
+        }
+
+        public void SetText(string dialog)
+        {
+            dialogueText.text = dialog;
+        }
+
+        public IEnumerator TypeDialougueText_CR(string dialogue, float readTimeInSeconds = DEFAULT_READ_TIME, bool persistAfterRead = false, bool keepPrev = false, float typingDelayInSeconds = DEFAULT_TYPE_DELAY)
+        {
+            if (!keepPrev)
+                dialogueText.text = "";
+
+            foreach (char letter in dialogue.ToCharArray())
+            {
+                dialogueText.text += letter;
+                yield return new WaitForSeconds(typingDelayInSeconds);
+
+            }
+            yield return new WaitForSeconds(readTimeInSeconds);
+
+            if (!persistAfterRead)
+                SetText("");
+        }
+
+        public IEnumerator TypeDialougueText_CR(string dialogue, float readTimeInSeconds, float typingDelayInSeconds)
+        {
+            yield return (TypeDialougueText_CR(dialogue, readTimeInSeconds, false, false, typingDelayInSeconds));
+        }
+
+        public IEnumerator TypeDialougueText_CR(string dialogue, bool persistAfterRead, bool keepPrev)
+        {
+            yield return (TypeDialougueText_CR(dialogue, DEFAULT_READ_TIME, persistAfterRead, keepPrev, DEFAULT_TYPE_DELAY));
 
         }
-        yield return new WaitForSeconds(readTimeInSeconds);
-
-        if (!persistAfterRead)
-            SetText("");
-    }
-
-    public IEnumerator TypeDialougueText_CR(string dialogue, float readTimeInSeconds, float typingDelayInSeconds)
-    {
-        yield return (TypeDialougueText_CR(dialogue, readTimeInSeconds, false, false, typingDelayInSeconds));
-    }
-
-    public IEnumerator TypeDialougueText_CR(string dialogue, bool persistAfterRead, bool keepPrev)
-    {
-        yield return (TypeDialougueText_CR(dialogue, DEFAULT_READ_TIME, persistAfterRead, keepPrev, DEFAULT_TYPE_DELAY));
-
-    }
 
 
-    public void SetActionsMenu()
-    {
-        ActionMenu.SetActive(true);
-        menuMode = MenuMode.Actions;
-        currentActiveMenu = ActionMenu;
-
-        if (ActionMenu.activeSelf)
-            buttonController.SetSelectedGameObject(ActionMenu.GetComponentInChildren<Button>().gameObject);
-
-    }
-
-    public void SetMovesMenu()
-    {
-        menuMode = MenuMode.Moves;
-        SetCurrentActiveMenu(MovesMenu);
-        UpdateMoveData();
-    }
-
-
-    public void UpdateMoveData()
-    {
-        var b = buttonController.currentSelectedGameObject.GetComponent<Button>();
-
-        if (ButtonMove.ContainsKey(b))
+        public void SetActionsMenu()
         {
-            Move m = ButtonMove[b];
-            ppText.text = $"PP {m.Pp}/{m.Base.MaxPP}";
-            if (m.Pp <= 0)
-                ppText.color = Color.red;
-            else
-                ppText.color = Color.HSVToRGB(0, 0, .20f);
-            moveTypeText.text = m.Base.Type.ToString();
+            ActionMenu.SetActive(true);
+            menuMode = MenuMode.Actions;
+            currentActiveMenu = ActionMenu;
+
+            if (ActionMenu.activeSelf)
+                buttonController.SetSelectedGameObject(ActionMenu.GetComponentInChildren<Button>().gameObject);
+
         }
-    }
 
-    void Update()
-    {
-
-        //if (input == null)
-          //  input = EventSystem.current.GetComponent<InputSystemUIInputModule>();
-
-        if (menuMode == MenuMode.Moves && input.move.ToInputAction().ReadValue<Vector2>() != Vector2.zero)
+        public void SetMovesMenu()
+        {
+            menuMode = MenuMode.Moves;
+            SetCurrentActiveMenu(MovesMenu);
             UpdateMoveData();
+        }
 
-        if (menuMode != MenuMode.None && input.cancel.action.triggered)
-            CancelButtonHandler();
-    }
 
-    public void CancelButtonHandler()
-    {
-        if (menuMode == MenuMode.Party || menuMode == MenuMode.Confirmation || menuMode == MenuMode.Forget_Move || menuMode == MenuMode.Bag)
+        public void UpdateMoveData()
         {
-            if (previousActive != null)
-                currentActiveMenu = previousActive;
+            var b = buttonController.currentSelectedGameObject.GetComponent<Button>();
 
-            OnCancelInput?.Invoke();
-            return;
+            if (ButtonMove.ContainsKey(b))
+            {
+                Move m = ButtonMove[b];
+                ppText.text = $"PP {m.Pp}/{m.Base.MaxPP}";
+                if (m.Pp <= 0)
+                    ppText.color = Color.red;
+                else
+                    ppText.color = Color.HSVToRGB(0, 0, .20f);
+                moveTypeText.text = m.Base.Type.ToString();
+            }
+        }
+
+        void Update()
+        {
+
+            //if (input == null)
+            //  input = EventSystem.current.GetComponent<InputSystemUIInputModule>();
+
+            if (menuMode == MenuMode.Moves && input.move.ToInputAction().ReadValue<Vector2>() != Vector2.zero)
+                UpdateMoveData();
+
+            if (menuMode != MenuMode.None && input.cancel.action.triggered)
+                CancelButtonHandler();
+        }
+
+        public void CancelButtonHandler()
+        {
+            if (menuMode == MenuMode.Party || menuMode == MenuMode.Confirmation || menuMode == MenuMode.Forget_Move || menuMode == MenuMode.Bag)
+            {
+                if (previousActive != null)
+                    currentActiveMenu = previousActive;
+
+                OnCancelInput?.Invoke();
+                return;
+
+            }
+            ReturnToActionMenu();
+        }
+
+        public void ReturnToActionMenu()
+        {
+
+            if (currentActiveMenu == ActionMenu || !currentActiveMenu)// && menuMode == MenuMode.Actions)
+                return;
+
+            currentActiveMenu.SetActive(false);
+            SetActionsMenu();
 
         }
-        ReturnToActionMenu();
-    }
-
-    public void ReturnToActionMenu()
-    {
-
-        if (currentActiveMenu == ActionMenu || !currentActiveMenu)// && menuMode == MenuMode.Actions)
-            return;
-
-        currentActiveMenu.SetActive(false);
-        SetActionsMenu();
-
-    }
 
 
-    public void SetMoveButtons(List<Move> moves)
-    {
-        ButtonMove = new Dictionary<Button, Move>();
-
-        Text bText;
-        int i = 0;
-        foreach (var b in moveButtuns)
+        public void SetMoveButtons(List<Move> moves)
         {
-            bText = b.GetComponentInChildren<Text>();
-            if (i < moves.Count)
-            {
-                b.enabled = true;
-                bText.text = moves[i].Base.name;
-                ButtonMove.Add(b, moves[i]);
-                b.interactable = true;
-                b.GetComponent<Image>().color = Color.white;
-            }
-            else
-            {
+            ButtonMove = new Dictionary<Button, Move>();
 
-                b.GetComponent<Image>().color = b.colors.disabledColor;
-                b.enabled = false;
+            Text bText;
+            int i = 0;
+            foreach (var b in moveButtuns)
+            {
+                bText = b.GetComponentInChildren<Text>();
+                if (i < moves.Count)
+                {
+                    b.enabled = true;
+                    bText.text = moves[i].Base.name;
+                    ButtonMove.Add(b, moves[i]);
+                    b.interactable = true;
+                    b.GetComponent<Image>().color = Color.white;
+                }
+                else
+                {
 
-                bText.text = " - ";
+                    b.GetComponent<Image>().color = b.colors.disabledColor;
+                    b.enabled = false;
+
+                    bText.text = " - ";
+                }
+                i++;
             }
-            i++;
         }
-    }
 
-    //Refactor
-    public void SetCurrentActiveMenu(GameObject menu, bool keepPrevious = false, MenuMode mode = MenuMode.None, Action onReturn = null)
-    {
-        menu.SetActive(true);
-        if (mode != MenuMode.None)
+        //Refactor
+        public void SetCurrentActiveMenu(GameObject menu, bool keepPrevious = false, MenuMode mode = MenuMode.None, Action onReturn = null)
+        {
+            menu.SetActive(true);
+            if (mode != MenuMode.None)
+                menuMode = mode;
+
+            if (currentActiveMenu != null)
+            {
+                if (keepPrevious)
+                {
+                    previousActive = currentActiveMenu;
+                    previousSelection = EventSystem.current.currentSelectedGameObject;
+                }
+                else
+                    currentActiveMenu.SetActive(false);
+            }
+
+            currentActiveMenu = menu;
+            if (onReturn != null)
+                OnCancelInput = onReturn;
+
+            buttonController.SetSelectedGameObject(currentActiveMenu.GetComponentInChildren<Button>().gameObject);
+        }
+
+        public void SetCurrentBattleScreen(pokeCopy.IGameScreen screen, Action onSelection = null, Action onReturn = null, MenuMode mode = MenuMode.None, bool keepPrevious = false)
+        {
+
+            if (currentActiveMenu != null)
+            {
+                if (keepPrevious)
+                {
+                    previousActive = currentActiveMenu;
+                    previousSelection = EventSystem.current.currentSelectedGameObject;
+                }
+                else
+                    currentActiveMenu.SetActive(false);
+            }
+
+            screen.Open(onSelection, onReturn);
             menuMode = mode;
 
-        if (currentActiveMenu != null)
-        {
-            if (keepPrevious)
-            {
-                previousActive = currentActiveMenu;
-                previousSelection = EventSystem.current.currentSelectedGameObject;
-            }
-            else
-                currentActiveMenu.SetActive(false);
+            currentActiveMenu = screen.GetGameObject();
+            OnCancelInput = screen.CancelButton;
         }
 
-        currentActiveMenu = menu;
-        if (onReturn != null)
-            OnCancelInput = onReturn;
 
-        buttonController.SetSelectedGameObject(currentActiveMenu.GetComponentInChildren<Button>().gameObject);
-    }
-
-    public void SetCurrentBattleScreen(pokeCopy.IGameScreen screen, Action onSelection = null, Action onReturn = null, MenuMode mode = MenuMode.None, bool keepPrevious = false)
-    {
-
-        if (currentActiveMenu != null)
+        public void CloseMenus()
         {
-            if (keepPrevious)
-            {
-                previousActive = currentActiveMenu;
-                previousSelection = EventSystem.current.currentSelectedGameObject;
-            }
-            else
-                currentActiveMenu.SetActive(false);
+            currentActiveMenu.SetActive(false);
+            if (previousActive != null)
+                previousActive.SetActive(false);
+            previousActive = null;
+            currentActiveMenu = null;
+            OnCancelInput = null;
+            subMenu = SubMenu.none;
+            menuMode = MenuMode.None;//to test
         }
 
-        screen.Open(onSelection, onReturn);
-        menuMode = mode;
 
-        currentActiveMenu = screen.GetGameObject();
-        OnCancelInput = screen.CancelButton;
+
+        public Move GetMove(Button moveButton)
+        {
+            return ButtonMove[moveButton];
+
+        }
+
+
+        public void SetCurrentByMode(MenuMode mode)
+        {
+
+        }
+
+        public void UpdateMoveDataByIndex()
+        {
+
+        }
+
+
     }
 
 
-    public void CloseMenus()
+    public enum MenuMode
     {
-        currentActiveMenu.SetActive(false);
-        if (previousActive != null)
-            previousActive.SetActive(false);
-        previousActive = null;
-        currentActiveMenu = null;
-        OnCancelInput = null;
-        subMenu = SubMenu.none;
-        menuMode = MenuMode.None;//to test
+        None,
+        Actions,
+        Moves,
+        Bag,
+        Party,
+        Sub_Party,
+        Sub_Bag,
+        Confirmation,
+        Forget_Move,
+        Busy
+
     }
 
-
-
-    public Move GetMove(Button moveButton)
+    public enum SubMenu
     {
-        return ButtonMove[moveButton];
+        none,
+        Sub_Party,
+        Sub_Bag,
+        Confirmation,
 
     }
-
-
-    public void SetCurrentByMode(MenuMode mode)
-    {
-
-    }
-
-    public void UpdateMoveDataByIndex()
-    {
-
-    }
-
-
-}
-
-
-public enum MenuMode
-{
-    None,
-    Actions,
-    Moves,
-    Bag,
-    Party,
-    Sub_Party,
-    Sub_Bag,
-    Confirmation,
-    Forget_Move,
-    Busy
-
-}
-
-public enum SubMenu
-{
-    none,
-    Sub_Party,
-    Sub_Bag,
-    Confirmation,
-
 }

--- a/Battle/TrainerData.cs
+++ b/Battle/TrainerData.cs
@@ -3,82 +3,88 @@ using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
 
-[CreateAssetMenu (menuName = "Character/Create New TrainerData")]
-public class TrainerData : ScriptableObject
+
+namespace pokeCopy
 {
-    [SerializeField] string Name;
-    [SerializeField] PokemonParty party;//
-    [SerializeField] Sprite battleSrpite;
-    [SerializeField] List<Pokemon> pokemons = new List<Pokemon>();
-    public PokemonTeam team { get; private set; }
 
-    public string _Name { get => Name; }
-    public PokemonParty Party { get => party;}
-    public Sprite BattleSrpite { get => battleSrpite;  }
-    public List<Pokemon> Pokemons { get => pokemons; }
-
-    [SerializeField] bool battleLost = false;
-
-    public void Awake()
+    [CreateAssetMenu(menuName = "Character/Create New TrainerData")]
+    public class TrainerData : ScriptableObject
     {
-       // pokemons = party.GetFullParty();
-       /*
-        
-        foreach (var p in pokemons)
+        [SerializeField] string Name;
+        [SerializeField] PokemonParty party;//
+        [SerializeField] Sprite battleSrpite;
+        [SerializeField] List<Pokemon> pokemons = new List<Pokemon>();
+        public PokemonTeam team { get; private set; }
+
+        public string _Name { get => Name; }
+        public PokemonParty Party { get => party; }
+        public Sprite BattleSrpite { get => battleSrpite; }
+        public List<Pokemon> Pokemons { get => pokemons; }
+
+        [SerializeField] bool battleLost = false;
+
+        public void Awake()
         {
-            p.Init();
-        }
-        */
-    }
+            // pokemons = party.GetFullParty();
+            /*
 
-    public void SetData(string name, PokemonParty party, Sprite sprite, PokemonTeam team)
-    {
-        Name = name;
-        this.party = party;
-        battleSrpite = sprite;
-        pokemons = party.GetFullParty();
-        this.team = team;
-        /*
-        foreach (var p in this.team.)
+             foreach (var p in pokemons)
+             {
+                 p.Init();
+             }
+             */
+        }
+
+        public void SetData(string name, PokemonParty party, Sprite sprite, PokemonTeam team)
         {
-            p.Init();
+            Name = name;
+            this.party = party;
+            battleSrpite = sprite;
+            pokemons = party.GetFullParty();
+            this.team = team;
+            /*
+            foreach (var p in this.team.)
+            {
+                p.Init();
+            }
+            */
         }
-        */
-    }
 
-    public Pokemon GetHealthy()
-    {
-        return pokemons.Where(x => x.HP > 0).FirstOrDefault();
-    }
+        public Pokemon GetHealthy()
+        {
+            return pokemons.Where(x => x.HP > 0).FirstOrDefault();
+        }
 
-    public void AddToParty(Pokemon p)
-    {
-        if (pokemons.Count >= 6)
-            return;
+        public void AddToParty(Pokemon p)
+        {
+            if (pokemons.Count >= 6)
+                return;
 
-        pokemons.Add(p);
+            pokemons.Add(p);
 
-    }
-    public void RemoveFromParty(int index)
-    {
-        if (pokemons.Count <= 1)
-            return;
+        }
+        public void RemoveFromParty(int index)
+        {
+            if (pokemons.Count <= 1)
+                return;
 
-        pokemons.RemoveAt(index);
-    }
+            pokemons.RemoveAt(index);
+        }
 
-    public Pokemon Retrive(int index)
-    {
-        return (index >= pokemons.Count) ? null : pokemons[index];
-    }
+        public Pokemon Retrive(int index)
+        {
+            return (index >= pokemons.Count) ? null : pokemons[index];
+        }
 
-    public void OnEndOfBattle(bool result)
-    {
-        battleLost = result;
-    }
+        public void OnEndOfBattle(bool result)
+        {
+            battleLost = result;
+        }
 
-    public bool GetBattleResult()
-    {
-        return battleLost;
+        public bool GetBattleResult()
+        {
+            return battleLost;
+        }
     }
 }
+

--- a/Battle/Unit.cs
+++ b/Battle/Unit.cs
@@ -2,88 +2,90 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Unit : MonoBehaviour
+namespace pokeCopy
 {
-    public PokemonBase Species { get; private set; }
-    public int lvl;
-    [SerializeField] Pokemon unitPokemon;
-    public Pokemon CrrPokemon { get { return unitPokemon; } }
-
-    public Animator animator;
-    //[SerializeField] new Animation animation;
-    [SerializeField] AnimationClip aniclip;
-    public ParticleSystem impact;
-    public AnimatorOverrideController aniControl;
-
-    [SerializeField] SpriteRenderer pImage;
-    [SerializeField] SpriteMask mask;
-    [SerializeField] BattleHud hud;
-    [SerializeField] bool isPlayerOrAlly;
-    public BattleHud BHud { get; set; }
-
-    public string unitName;
-    public int unitLevel;
-
-    // public int damage;
-
-
-    public Move MoveOfChoice { get; set; }
-    public Move LastUsed { get; set; }
-
-
-    public Dictionary<Stat, int> StatStages { get; set; }
-
-
-    // public Queue<string> StatusChange { get; private set; } = new Queue<string>();
-
-    PokemonType effctvType1;
-    PokemonType effctvType2;
-
-    public Unit Leecher { get; private set; }
-    public bool IsPlayerOrAlly { get => isPlayerOrAlly; set => isPlayerOrAlly = value; }
-
-    public void SetUpUnit(Pokemon p, BattleHud hud = null)
+    public class Unit : MonoBehaviour
     {
-        unitPokemon = p;
-        Species = unitPokemon.Base;//
+        public PokemonBase Species { get; private set; }
+        public int lvl;
+        [SerializeField] Pokemon unitPokemon;
+        public Pokemon CrrPokemon { get { return unitPokemon; } }
 
-        unitName = ((unitPokemon.NickName.Length > 0) && !(unitPokemon.NickName.StartsWith(" ")) || (unitPokemon.NickName == null)) ? unitPokemon.NickName : unitPokemon.Species;
-        name = unitName;
+        public Animator animator;
+        //[SerializeField] new Animation animation;
+        [SerializeField] AnimationClip aniclip;
+        public ParticleSystem impact;
+        public AnimatorOverrideController aniControl;
 
-        effctvType1 = Species.Type1;
-        effctvType2 = Species.Type2;
+        [SerializeField] SpriteRenderer pImage;
+        [SerializeField] SpriteMask mask;
+        [SerializeField] BattleHud hud;
+        [SerializeField] bool isPlayerOrAlly;
+        public BattleHud BHud { get; set; }
 
-        SetBoosts();
-        unitPokemon.RemoveAllVolat();
-        Leecher = null;
-        SetSprite();
-        foreach (var m in unitPokemon.MoveSet)
-            m.LastUsedTurn = 0;
-        pImage.transform.localScale = Vector3.one;
-        pImage.color = Color.white; 
+        public string unitName;
+        public int unitLevel;
 
-        MoveOfChoice = null;
-        if (hud != null && BHud == null)
-            BHud = hud;
-        BHud.SetHUD(this);
-        if (animator == null)
+        // public int damage;
+
+
+        public Move MoveOfChoice { get; set; }
+        public Move LastUsed { get; set; }
+
+
+        public Dictionary<Stat, int> StatStages { get; set; }
+
+
+        // public Queue<string> StatusChange { get; private set; } = new Queue<string>();
+
+        PokemonType effctvType1;
+        PokemonType effctvType2;
+
+        public Unit Leecher { get; private set; }
+        public bool IsPlayerOrAlly { get => isPlayerOrAlly; set => isPlayerOrAlly = value; }
+
+        public void SetUpUnit(Pokemon p, BattleHud hud = null)
         {
-            animator = GetComponentInChildren<Animator>();
+            unitPokemon = p;
+            Species = unitPokemon.Base;//
+
+            unitName = ((unitPokemon.NickName.Length > 0) && !(unitPokemon.NickName.StartsWith(" ")) || (unitPokemon.NickName == null)) ? unitPokemon.NickName : unitPokemon.Species;
+            name = unitName;
+
+            effctvType1 = Species.Type1;
+            effctvType2 = Species.Type2;
+
+            SetBoosts();
+            unitPokemon.RemoveAllVolat();
+            Leecher = null;
+            SetSprite();
+            foreach (var m in unitPokemon.MoveSet)
+                m.LastUsedTurn = 0;
+            pImage.transform.localScale = Vector3.one;
+            pImage.color = Color.white;
+
+            MoveOfChoice = null;
+            if (hud != null && BHud == null)
+                BHud = hud;
+            BHud.SetHUD(this);
+            if (animator == null)
+            {
+                animator = GetComponentInChildren<Animator>();
+            }
+            aniControl = (AnimatorOverrideController)animator.runtimeAnimatorController;
+            animator.Play("Battle_EnemyBegin");
+
         }
-        aniControl = (AnimatorOverrideController)animator.runtimeAnimatorController;
-        animator.Play("Battle_EnemyBegin");
 
-    }
+        public void SetAnimatorControl(AnimatorOverrideController newControl)
+        {
+            animator.runtimeAnimatorController = newControl;
+            aniControl = (AnimatorOverrideController)animator.runtimeAnimatorController;
+        }
 
-    public void SetAnimatorControl(AnimatorOverrideController newControl)
-    {
-        animator.runtimeAnimatorController = newControl;
-        aniControl = (AnimatorOverrideController)animator.runtimeAnimatorController;
-    }
-
-    void SetBoosts()
-    {
-        StatStages = new Dictionary<Stat, int>
+        void SetBoosts()
+        {
+            StatStages = new Dictionary<Stat, int>
         {
             { Stat.Attack, 0},
             { Stat.Defense, 0},
@@ -94,295 +96,297 @@ public class Unit : MonoBehaviour
             { Stat.Accuracy, 0},
             { Stat.Critical, 0},
         };
-    }
-
-    public void ApplyStatStage(List<StatModsStage> changes)
-    {
-        List<Stat> highest = new List<Stat>();
-        List<Stat> lowest = new List<Stat>();
-
-        string quote = $"{unitName}'s ";
-        int nameEndIndex = quote.Length;
-
-        foreach (var st in changes)
-        {
-            var stat = st.stat;
-
-            if (Mathf.Abs(StatStages[stat]) < 6)
-                continue;
-
-            if (StatStages[stat] > 0)
-            {
-                highest.Add(stat);
-                continue;
-            }
-            lowest.Add(stat);
         }
 
-        foreach (var st in changes)
+        public void ApplyStatStage(List<StatModsStage> changes)
         {
-            if (st.stage == 0) continue;
-            if (quote.Length > nameEndIndex)
-                quote = quote.Remove(nameEndIndex);
+            List<Stat> highest = new List<Stat>();
+            List<Stat> lowest = new List<Stat>();
 
-            Stat stat = st.stat;
-            var stage = StatStages[stat];
-            var change = st.stage;
+            string quote = $"{unitName}'s ";
+            int nameEndIndex = quote.Length;
 
-            if (highest.IndexOf(stat) > 0)
-                continue;
-
-            if (lowest.IndexOf(stat) > 0)
-                continue;
-
-            if (Mathf.Abs(stage) >= 6)
+            foreach (var st in changes)
             {
-                quote += "won't go ";
+                var stat = st.stat;
 
-                if (highest.Contains(stat))
-                    quote += "higher.";
+                if (Mathf.Abs(StatStages[stat]) < 6)
+                    continue;
 
-                if (lowest.Contains(stat))
-                    quote += "lower.";
-
-                if (highest.Count > 1 || lowest.Count > 1)
+                if (StatStages[stat] > 0)
                 {
-                    quote = quote.Insert(nameEndIndex, "stats ");
-                    Debug.Log(quote.LastIndexOf("won't go "));
-                    quote = quote.Insert(quote.LastIndexOf(" ") + 1, "any ");
+                    highest.Add(stat);
+                    continue;
                 }
-                else
-                    quote = quote.Insert(nameEndIndex, ((lowest.Contains(stat)) ? $"{lowest[lowest.IndexOf(stat)]} " : $"{highest[highest.IndexOf(stat)]} "));
+                lowest.Add(stat);
+            }
+
+            foreach (var st in changes)
+            {
+                if (st.stage == 0) continue;
+                if (quote.Length > nameEndIndex)
+                    quote = quote.Remove(nameEndIndex);
+
+                Stat stat = st.stat;
+                var stage = StatStages[stat];
+                var change = st.stage;
+
+                if (highest.IndexOf(stat) > 0)
+                    continue;
+
+                if (lowest.IndexOf(stat) > 0)
+                    continue;
+
+                if (Mathf.Abs(stage) >= 6)
+                {
+                    quote += "won't go ";
+
+                    if (highest.Contains(stat))
+                        quote += "higher.";
+
+                    if (lowest.Contains(stat))
+                        quote += "lower.";
+
+                    if (highest.Count > 1 || lowest.Count > 1)
+                    {
+                        quote = quote.Insert(nameEndIndex, "stats ");
+                        Debug.Log(quote.LastIndexOf("won't go "));
+                        quote = quote.Insert(quote.LastIndexOf(" ") + 1, "any ");
+                    }
+                    else
+                        quote = quote.Insert(nameEndIndex, ((lowest.Contains(stat)) ? $"{lowest[lowest.IndexOf(stat)]} " : $"{highest[highest.IndexOf(stat)]} "));
+
+                    CrrPokemon.StatusChangeQuote.Enqueue(quote);
+                    continue;
+                }
+
+                quote += $"{stat} ";
+
+                StatStages[stat] = Mathf.Clamp(StatStages[stat] + change, -6, +6);
+                // details.Add(new EffectDetails(StatStages[stat], stage));
+
+                if (change > 1)
+                    quote += "sharply ";
+                if (change > 0)
+                    quote += "rose!";
+
+                if (change < -1)
+                    quote += "harshly ";
+                if (change < 0)
+                    quote += "fell!";
+
+
+                //play animation on battle sistem intead of here? won't be hidden but would nedd a return value from this function
+                if (change > 0)
+                    animator.Play("Battle_EnemyUpStat");
+                if (change < 0)
+                    animator.Play("Battle_EnemyDownStat");
 
                 CrrPokemon.StatusChangeQuote.Enqueue(quote);
-                continue;
+            }
+        }
+
+        public void ApplyCondition(ConditionID status, Unit leecher = null)
+        {
+            if (ConditionsDB.Conditions.ContainsKey(status))
+                CrrPokemon.ReceiveStatus(status);
+
+            if (ConditionsDB.VolatConditions.ContainsKey(status))
+                CrrPokemon.ReceiveVolatile(status, this, leecher);
+            //CrrPokemon.StatusChange.Enqueue($"{CrrPokemon._name} {CrrPokemon.Status.StartMessage}");
+        }
+
+        public bool SetLeecher(Unit root)
+        {
+            if (Leecher == null)
+            {
+                Leecher = root;
+                return true;
+            }
+            return false;
+        }
+
+        //Is there a way to use conditions instead of the unit
+
+        public void RemoveSeeds()
+        {
+            Leecher = null;
+        }
+
+        public IEnumerator LeechSeedEffect_CR()
+        {
+            var leechedHp = CrrPokemon.OnEndOfRoundEffects();
+            if (leechedHp == null || Leecher == null)
+                yield break;
+
+
+            yield return BHud.WaitHpUpdat_CR();
+            Leecher.CrrPokemon.TakeHeal(leechedHp.Value);
+            yield return Leecher.BHud.WaitHpUpdat_CR();
+
+        }
+
+        void SetSprite()
+        {
+            if (!IsPlayerOrAlly)
+            {
+                pImage.sprite = Species.Front;
+                mask.sprite = pImage.sprite;
+                return;
+            }
+            pImage.gameObject.transform.localScale = Vector3.one;
+            pImage.sprite = Species.Back;
+            mask.sprite = pImage.sprite;
+
+        }
+
+        public int GetStat(Stat stat)
+        {
+            int statVal = CrrPokemon.GetBaseStat(stat);
+
+            int stage = StatStages[stat];
+
+
+            if (stage >= 0)
+                return Mathf.FloorToInt(statVal * BoostTable.GetBoostValue(stage));
+
+            return Mathf.FloorToInt(statVal / BoostTable.GetBoostValue(-stage));
+
+        }
+
+        int GetCritStat(Stat stat, float crit)
+        {
+            if (crit > 1f)
+            {
+                if ((stat == Stat.Attack || stat == Stat.SpecialAtk) && StatStages[stat] < 0)
+                    return CrrPokemon.GetBaseStat(stat);
+
+                if ((stat == Stat.Defense || stat == Stat.SpecialDef) && StatStages[stat] > 0)
+                    return CrrPokemon.GetBaseStat(stat);
             }
 
-            quote += $"{stat} ";
-
-            StatStages[stat] = Mathf.Clamp(StatStages[stat] + change, -6, +6);
-            // details.Add(new EffectDetails(StatStages[stat], stage));
-
-            if (change > 1)
-                quote += "sharply ";
-            if (change > 0)
-                quote += "rose!";
-
-            if (change < -1)
-                quote += "harshly ";
-            if (change < 0)
-                quote += "fell!";
-
-
-            //play animation on battle sistem intead of here? won't be hidden but would nedd a return value from this function
-            if (change > 0)
-                animator.Play("Battle_EnemyUpStat");
-            if (change < 0)
-                animator.Play("Battle_EnemyDownStat");
-
-            CrrPokemon.StatusChangeQuote.Enqueue(quote);
-        }
-    }
-
-    public void ApplyCondition(ConditionID status, Unit leecher = null)
-    {
-        if (ConditionsDB.Conditions.ContainsKey(status))
-            CrrPokemon.ReceiveStatus(status);
-
-        if (ConditionsDB.VolatConditions.ContainsKey(status)) 
-            CrrPokemon.ReceiveVolatile(status, this, leecher);
-        //CrrPokemon.StatusChange.Enqueue($"{CrrPokemon._name} {CrrPokemon.Status.StartMessage}");
-    }
-
-    public bool SetLeecher(Unit root)
-    {
-        if (Leecher == null)
-        {
-            Leecher = root;
-            return true;
-        }
-        return false;
-    }
-
-    //Is there a way to use conditions instead of the unit
-
-    public void RemoveSeeds()
-    {
-        Leecher = null;
-    }
-
-    public IEnumerator LeechSeedEffect_CR()
-    {
-        var leechedHp = CrrPokemon.OnEndOfRoundEffects();
-        if (leechedHp == null || Leecher == null)
-            yield break;
-
-
-        yield return BHud.WaitHpUpdat_CR();
-        Leecher.CrrPokemon.TakeHeal(leechedHp.Value);
-        yield return Leecher.BHud.WaitHpUpdat_CR();
-
-    }
-
-    void SetSprite()
-    {
-        if (!IsPlayerOrAlly)
-        {
-            pImage.sprite = Species.Front;
-            mask.sprite = pImage.sprite;
-            return;
-        }
-        pImage.gameObject.transform.localScale = Vector3.one;
-        pImage.sprite = Species.Back;
-        mask.sprite = pImage.sprite;
-
-    }
-
-    public int GetStat(Stat stat)
-    {
-        int statVal = CrrPokemon.GetBaseStat(stat);
-
-        int stage = StatStages[stat];
-
-
-        if (stage >= 0)
-            return Mathf.FloorToInt(statVal * BoostTable.GetBoostValue(stage));
-
-        return Mathf.FloorToInt(statVal / BoostTable.GetBoostValue(-stage));
-
-    }
-
-    int GetCritStat(Stat stat, float crit)
-    {
-        if (crit > 1f)
-        {
-            if ((stat == Stat.Attack || stat == Stat.SpecialAtk) && StatStages[stat] < 0)
-                return CrrPokemon.GetBaseStat(stat);
-
-            if ((stat == Stat.Defense || stat == Stat.SpecialDef) && StatStages[stat] > 0)
-                return CrrPokemon.GetBaseStat(stat);
+            return GetStat(stat);
         }
 
-        return GetStat(stat);
-    }
 
-
-    public DamageDetails TakeMoveDamage(Move move, Unit atker)
-    {
-        PokemonBase self = Species;
-        PokemonBase atkerBase = atker.Species;
-
-        int incrCrit = move.Base.IncreasedCritRatio;
-        MoveCategory category = move.Base.Category;
-        PokemonType moveType = move.Base.Type;
-
-        //DAMAGE CACULUS
-
-        float crit = ((BoostTable.GetCritBoost(StatStages[Stat.Critical] + incrCrit) * 100) > (Random.value * 100f)) ? 2f : 1f;
-
-        int atk = (category == MoveCategory.Special) ? atker.GetCritStat(Stat.SpecialAtk, crit) : atker.GetCritStat(Stat.Attack, crit); ;
-        int def = (category == MoveCategory.Special) ? GetCritStat(Stat.SpecialDef, crit) : GetCritStat(Stat.Defense, crit); 
-
-
-        float eff = Effectiveness.GetAllEffectivenesses(moveType, self.Type1, self.Type2);
-        float aff = Effectiveness.GetAllAffinities(moveType, atkerBase.Type1, atkerBase.Type2);
-        // float burn = (atker.CrrPokemon.Status?.Id == ConditionID.brn && category == MoveCategory.Physical) ? .5f : 1f;
-
-        float modifiers = Random.Range(0.85f, 1f) * eff * aff * crit;// * burn;
-
-        float others = OtherDmgMods(atker, category);//
-
-
-        //check calculus
-        var lvlFactor = (2* atker.CrrPokemon.Level + 10) / 250f;
-        float baseDmg = lvlFactor * move.Base.Power * (atk / def) + 2;
-
-        int damage = Mathf.FloorToInt(baseDmg * modifiers * others);
-
-
-        var damageDetails = new DamageDetails()
+        public DamageDetails TakeMoveDamage(Move move, Unit atker)
         {
-            Effectiveness = eff,
-            Critical = crit,
-            Fainted = CrrPokemon.TakeDamage(damage),
-            Damage = damage,
-        };
+            PokemonBase self = Species;
+            PokemonBase atkerBase = atker.Species;
+
+            int incrCrit = move.Base.IncreasedCritRatio;
+            MoveCategory category = move.Base.Category;
+            PokemonType moveType = move.Base.Type;
+
+            //DAMAGE CACULUS
+
+            float crit = ((BoostTable.GetCritBoost(StatStages[Stat.Critical] + incrCrit) * 100) > (Random.value * 100f)) ? 2f : 1f;
+
+            int atk = (category == MoveCategory.Special) ? atker.GetCritStat(Stat.SpecialAtk, crit) : atker.GetCritStat(Stat.Attack, crit); ;
+            int def = (category == MoveCategory.Special) ? GetCritStat(Stat.SpecialDef, crit) : GetCritStat(Stat.Defense, crit);
 
 
-        //OTHER EFFECTS
+            float eff = Effectiveness.GetAllEffectivenesses(moveType, self.Type1, self.Type2);
+            float aff = Effectiveness.GetAllAffinities(moveType, atkerBase.Type1, atkerBase.Type2);
+            // float burn = (atker.CrrPokemon.Status?.Id == ConditionID.brn && category == MoveCategory.Physical) ? .5f : 1f;
 
-        //put in a separete function that deals with all changes in status caused by offensive moves
-        if (CrrPokemon.Status?.Id == ConditionID.frz && moveType == PokemonType.Fire)
-            CrrPokemon.RecoverFromStatus();
+            float modifiers = Random.Range(0.85f, 1f) * eff * aff * crit;// * burn;
+
+            float others = OtherDmgMods(atker, category);//
 
 
-        //do recoil here using atker?
+            //check calculus
+            var lvlFactor = (2 * atker.CrrPokemon.Level + 10) / 250f;
+            float baseDmg = lvlFactor * move.Base.Power * (atk / def) + 2;
 
-        return damageDetails;
-    }
+            int damage = Mathf.FloorToInt(baseDmg * modifiers * others);
 
-    float OtherDmgMods(Unit atker, MoveCategory category)
-    {
-        var mod = 1f;
-        mod *= atker.CrrPokemon.Status?.GetOnDamageMod?.Invoke(category) ?? 1f;
 
-        return mod;
-    }
+            var damageDetails = new DamageDetails()
+            {
+                Effectiveness = eff,
+                Critical = crit,
+                Fainted = CrrPokemon.TakeDamage(damage),
+                Damage = damage,
+            };
 
-    public DamageDetails TakeFixedDamage(int damage)
-    {
-        var details = new DamageDetails()
-        {
-            Effectiveness = 1f,
-            Critical = 1f,
-            Fainted = CrrPokemon.TakeDamage(damage)
-        };
 
-        return details;
-    }
+            //OTHER EFFECTS
 
-    //Use a delegate to handle diferent behaviours.
-    //Make a DB for diferent Behaves? Use Nature of a Pokemon to influence the liklyhood of use more offenssive attacks or more status moves etc.
-    //Nature influence tatics that inlfuence the MoveOfChoice
-    //use lambdas?
-    public void SetMoveToUse(Unit opponent = null, UnitTatics trainnerTatic = UnitTatics.Random)
-    {
+            //put in a separete function that deals with all changes in status caused by offensive moves
+            if (CrrPokemon.Status?.Id == ConditionID.frz && moveType == PokemonType.Fire)
+                CrrPokemon.RecoverFromStatus();
 
-        //get crrtPokemon nature if wild, else, use providaded trainer tatic, overriding nature behaviour.
-        // opponet is used to addapt depending on the enemies actions, specialy last usedmove
 
-        if (MoveOfChoice?.isCharged == false)
-        {
-            MoveOfChoice.isCharged = true;
-            return;
+            //do recoil here using atker?
+
+            return damageDetails;
         }
 
-        MoveOfChoice = CrrPokemon.GetRandomMove();
-        if (MoveOfChoice?.Base.HasChargingTurn == true)
-            MoveOfChoice.isCharged = false;
+        float OtherDmgMods(Unit atker, MoveCategory category)
+        {
+            var mod = 1f;
+            mod *= atker.CrrPokemon.Status?.GetOnDamageMod?.Invoke(category) ?? 1f;
+
+            return mod;
+        }
+
+        public DamageDetails TakeFixedDamage(int damage)
+        {
+            var details = new DamageDetails()
+            {
+                Effectiveness = 1f,
+                Critical = 1f,
+                Fainted = CrrPokemon.TakeDamage(damage)
+            };
+
+            return details;
+        }
+
+        //Use a delegate to handle diferent behaviours.
+        //Make a DB for diferent Behaves? Use Nature of a Pokemon to influence the liklyhood of use more offenssive attacks or more status moves etc.
+        //Nature influence tatics that inlfuence the MoveOfChoice
+        //use lambdas?
+        public void SetMoveToUse(Unit opponent = null, UnitTatics trainnerTatic = UnitTatics.Random)
+        {
+
+            //get crrtPokemon nature if wild, else, use providaded trainer tatic, overriding nature behaviour.
+            // opponet is used to addapt depending on the enemies actions, specialy last usedmove
+
+            if (MoveOfChoice?.isCharged == false)
+            {
+                MoveOfChoice.isCharged = true;
+                return;
+            }
+
+            MoveOfChoice = CrrPokemon.GetRandomMove();
+            if (MoveOfChoice?.Base.HasChargingTurn == true)
+                MoveOfChoice.isCharged = false;
 
 
-        aniControl["Battle_EnemyAttack"] = MoveOfChoice.Base.OpntAnimation;
+            aniControl["Battle_EnemyAttack"] = MoveOfChoice.Base.OpntAnimation;
+
+        }
+
+        public void PlayImpact(object targetO)
+        {
+            var target = (Unit)targetO;
+            target.animator.Play("BattlePlayer_Impact");
+            target.impact.Play();
+        }
+
+        public void ResetSprite()
+        {
+            pImage.transform.localScale = Vector3.one;
+            pImage.color = Color.white;
+
+        }
 
     }
 
-    public void PlayImpact(object targetO)
+    public enum UnitTatics
     {
-        var target = (Unit)targetO;
-        target.animator.Play("BattlePlayer_Impact");
-        target.impact.Play();
+        Random, Aggressive, Defensive, Suport,
     }
 
-    public void ResetSprite()
-    {
-        pImage.transform.localScale = Vector3.one;
-        pImage.color = Color.white;
-
-    }
-
-}
-
-public enum UnitTatics
-{
-    Random, Aggressive, Defensive, Suport,
 }

--- a/Controllers/CharMovement.cs
+++ b/Controllers/CharMovement.cs
@@ -2,124 +2,128 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class CharMovement : MonoBehaviour
+namespace pokeCopy
 {
-    public Animator animator;
-    [SerializeField] float moveSpeed = 5f;
-    float offset = -0.3f;
 
-
-    public bool IsMoving { get; private set; }
-
-    private void Awake()
+    public class CharMovement : MonoBehaviour
     {
-        animator = GetComponentInChildren<Animator>();
-        SnapPositionToGrid(transform.position);
-    }
-
-    private void SetIsMoving(bool value)
-    {
-        IsMoving = value;
-        AnimatorUpdate();
-
-    }
-
-    public void SnapPositionToGrid(Vector3 position)
-    {
-        position.x = Mathf.Floor(position.x) + .5f;
-        position.y = Mathf.Floor(position.y) + .5f + offset;
-        transform.position = position;
-    }
-
-    public IEnumerator Move(Vector2 moveVec, System.Action OnMoveOver = null)
-    {
-        if (moveVec == Vector2.zero)
-            yield break;
-
-        animator.SetFloat("Horizontal", Mathf.Clamp(moveVec.x, -1, 1));
-        animator.SetFloat("Vertical", Mathf.Clamp(moveVec.y, -1, 1));
+        public Animator animator;
+        [SerializeField] float moveSpeed = 5f;
+        float offset = -0.3f;
 
 
-        var targetPos = transform.position;
-        targetPos.x += Mathf.Round(moveVec.x);
-        targetPos.y += Mathf.Round(moveVec.y);
+        public bool IsMoving { get; private set; }
 
-        //if (!IsWakable(targetPos))
-        if (!IsPathClear(targetPos))
-            yield break;
-
-        SetIsMoving(true);
-
-        //UpdateAnimation();
-        while ((targetPos - transform.position).sqrMagnitude > Mathf.Epsilon)
+        private void Awake()
         {
+            animator = GetComponentInChildren<Animator>();
+            SnapPositionToGrid(transform.position);
+        }
 
-            transform.position = Vector3.MoveTowards(transform.position, targetPos, moveSpeed * Time.deltaTime);
-            // animator.SetFloat("Speed", movement.sqrMagnitude);
-            yield return null;
+        private void SetIsMoving(bool value)
+        {
+            IsMoving = value;
+            AnimatorUpdate();
 
         }
 
-        //UpdateAnimation();
-        //animator.SetFloat("Speed", movement.normalized.sqrMagnitude);
-
-        transform.position = targetPos;
-
-        SetIsMoving(false);
-
-        OnMoveOver?.Invoke();
-
-
-    }
-
-    public void AnimatorUpdate()
-    {
-        animator.SetBool("IsMoving", IsMoving);
-
-    }
-
-
-    bool IsPathClear(Vector3 position)
-    {
-        var diff = position - transform.position;
-        var dir = diff.normalized;
-
-        if (Physics2D.BoxCast(transform.position + dir, new Vector2(0.2f, 0.2f), 0f, dir, diff.magnitude -1, LayersManager.i.Unwalkable | LayersManager.i.Interactable | LayersManager.i.PlayerLayer) == true)
-            return false;
-
-        return true;
-    }
-
-
-    bool IsWakable(Vector3 position)
-    {
-        //if (Physics2D.OverlapCircle(position, 0.3f, LayersManager.i.Unwalkable | LayersManager.i.Interactable | LayersManager.i.PlayerLayer) != null)
-         if (Physics2D.Linecast((Vector2)transform.position + new Vector2(animator.GetFloat("Horizontal"), animator.GetFloat("Vertical")), position, LayersManager.i.Unwalkable | LayersManager.i.Interactable | LayersManager.i.PlayerLayer))
-            return false;
-
-
-        return true;
-    }
-
-
-
-    public void LookTowrds(Vector3 direction)
-    {
-        var xdif = Mathf.Floor(direction.x) - Mathf.Floor(transform.position.x);
-        var ydif = Mathf.Floor(direction.y) - Mathf.Floor(transform.position.y);
-
-        if (xdif == 0 || ydif == 0)
+        public void SnapPositionToGrid(Vector3 position)
         {
-            animator.SetFloat("Horizontal", Mathf.Clamp(xdif, -1, 1));
-            animator.SetFloat("Vertical", Mathf.Clamp(ydif, -1, 1));
+            position.x = Mathf.Floor(position.x) + .5f;
+            position.y = Mathf.Floor(position.y) + .5f + offset;
+            transform.position = position;
+        }
+
+        public IEnumerator Move(Vector2 moveVec, System.Action OnMoveOver = null)
+        {
+            if (moveVec == Vector2.zero)
+                yield break;
+
+            animator.SetFloat("Horizontal", Mathf.Clamp(moveVec.x, -1, 1));
+            animator.SetFloat("Vertical", Mathf.Clamp(moveVec.y, -1, 1));
+
+
+            var targetPos = transform.position;
+            targetPos.x += Mathf.Round(moveVec.x);
+            targetPos.y += Mathf.Round(moveVec.y);
+
+            //if (!IsWakable(targetPos))
+            if (!IsPathClear(targetPos))
+                yield break;
+
+            SetIsMoving(true);
+
+            //UpdateAnimation();
+            while ((targetPos - transform.position).sqrMagnitude > Mathf.Epsilon)
+            {
+
+                transform.position = Vector3.MoveTowards(transform.position, targetPos, moveSpeed * Time.deltaTime);
+                // animator.SetFloat("Speed", movement.sqrMagnitude);
+                yield return null;
+
+            }
+
+            //UpdateAnimation();
+            //animator.SetFloat("Speed", movement.normalized.sqrMagnitude);
+
+            transform.position = targetPos;
+
+            SetIsMoving(false);
+
+            OnMoveOver?.Invoke();
+
 
         }
-        else
-            Debug.LogError("Error in LookTowrds: Character can't look diagonaly."); 
 
+        public void AnimatorUpdate()
+        {
+            animator.SetBool("IsMoving", IsMoving);
+
+        }
+
+
+        bool IsPathClear(Vector3 position)
+        {
+            var diff = position - transform.position;
+            var dir = diff.normalized;
+
+            if (Physics2D.BoxCast(transform.position + dir, new Vector2(0.2f, 0.2f), 0f, dir, diff.magnitude - 1, LayersManager.i.Unwalkable | LayersManager.i.Interactable | LayersManager.i.PlayerLayer) == true)
+                return false;
+
+            return true;
+        }
+
+
+        bool IsWakable(Vector3 position)
+        {
+            //if (Physics2D.OverlapCircle(position, 0.3f, LayersManager.i.Unwalkable | LayersManager.i.Interactable | LayersManager.i.PlayerLayer) != null)
+            if (Physics2D.Linecast((Vector2)transform.position + new Vector2(animator.GetFloat("Horizontal"), animator.GetFloat("Vertical")), position, LayersManager.i.Unwalkable | LayersManager.i.Interactable | LayersManager.i.PlayerLayer))
+                return false;
+
+
+            return true;
+        }
+
+
+
+        public void LookTowrds(Vector3 direction)
+        {
+            var xdif = Mathf.Floor(direction.x) - Mathf.Floor(transform.position.x);
+            var ydif = Mathf.Floor(direction.y) - Mathf.Floor(transform.position.y);
+
+            if (xdif == 0 || ydif == 0)
+            {
+                animator.SetFloat("Horizontal", Mathf.Clamp(xdif, -1, 1));
+                animator.SetFloat("Vertical", Mathf.Clamp(ydif, -1, 1));
+
+            }
+            else
+                Debug.LogError("Error in LookTowrds: Character can't look diagonaly.");
+
+
+
+        }
 
 
     }
-
-
 }

--- a/Controllers/PlayerMovement.cs
+++ b/Controllers/PlayerMovement.cs
@@ -7,316 +7,320 @@ using UnityEngine.SceneManagement;
 using pokeCopy;
 using System.Linq;
 
-public class PlayerMovement : MonoBehaviour, ISavable, INamable
+namespace pokeCopy
 {
-    [SerializeField] string playerName;
-    [SerializeField] float moveSpeed = 5f;
-    [SerializeField] float runSpeed = 7f;
-
-    //float speed;
-    readonly float offset = -0.3f;
-
-    [SerializeField] Rigidbody2D rb;
-
-    [SerializeField] Animator animator;
-    [SerializeField] Sprite battleSprite;
-
-    Vector2 movement;
-
-    bool isMoving;
-    bool isRunning;
-
-    PlayerInputActions inputActions;
-    public PlayerInputActions InputActions { get => inputActions; }
-    public Sprite BattleSprite { get => battleSprite; }
-    public bool IsMoving => isMoving;
-
-    public string InGameName  => playerName;
-
-    public string Name { get => playerName; }
-
-    //    [SerializeField] bool isNorm = true;
-
-
-    public void Awake()
+    public class PlayerMovement : MonoBehaviour, ISavable, INamable
     {
+        [SerializeField] string playerName;
+        [SerializeField] float moveSpeed = 5f;
+        [SerializeField] float runSpeed = 7f;
 
-        if (GameManager.Instance != null)
+        //float speed;
+        readonly float offset = -0.3f;
+
+        [SerializeField] Rigidbody2D rb;
+
+        [SerializeField] Animator animator;
+        [SerializeField] Sprite battleSprite;
+
+        Vector2 movement;
+
+        bool isMoving;
+        bool isRunning;
+
+        PlayerInputActions inputActions;
+        public PlayerInputActions InputActions { get => inputActions; }
+        public Sprite BattleSprite { get => battleSprite; }
+        public bool IsMoving => isMoving;
+
+        public string InGameName => playerName;
+
+        public string Name { get => playerName; }
+
+        //    [SerializeField] bool isNorm = true;
+
+
+        public void Awake()
         {
-            if (GameManager.Instance.Player != this)
-                Destroy(this.gameObject);
+
+            if (GameManager.Instance != null)
+            {
+                if (GameManager.Instance.Player != this)
+                    Destroy(this.gameObject);
+
+
+            }
+
+
+            //DontDestroyOnLoad(gameObject);
+
+
+            if (inputActions == null)
+            {
+                inputActions = new PlayerInputActions();
+                Debug.Log("New input");
+            }
+            Debug.Log("Player woke");
+
+            inputActions.PlayerDigital.Enable();
+            // inputActions.Player.Move.performed += MoveAction;
+
+            //Debug.Log(ExpTable.GetSize());
+            // Debug.Log(ExpTable.GetNumGrothTypes());
+
+        }
+        public void Start()
+        {
+            SnapPositionToGrid(transform.position);
+        }
+
+        public void SnapPositionToGrid(Vector3 position)
+        {
+            animator.SetBool("IsMoving", isMoving);
+
+            while (!IsWakable(position))
+            {
+                --position.x;
+                --position.y;
+
+            }
+
+            position.x = Mathf.Floor(position.x) + .5f;
+            position.y = Mathf.Floor(position.y) + .5f + offset;
+            transform.position = position;
+        }
+
+
+        public void OnEnable()
+        {
+            if (GameManager.Instance != null && GameManager.Instance.IsBattleAScene)
+            {
+                var d = GameManager.Instance.BattleSceneData.RetriveDirection();
+                animator.SetFloat("Horizontal", d.x);
+                animator.SetFloat("Vertical", d.y);
+
+                transform.position = GameManager.Instance.BattleSceneData.ReturnPosition();
+                GameManager.Instance.BattleSceneData.SetPlayerCharSprite(battleSprite);
+
+            }
+            inputActions.PlayerDigital.Enable();
 
 
         }
 
-
-        //DontDestroyOnLoad(gameObject);
-
-
-        if (inputActions == null)
+        // Update is called once per frame
+        void Update()
         {
-            inputActions = new PlayerInputActions();
-            Debug.Log("New input");
-        }
-        Debug.Log("Player woke");
-
-        inputActions.PlayerDigital.Enable();
-        // inputActions.Player.Move.performed += MoveAction;
-
-        //Debug.Log(ExpTable.GetSize());
-        // Debug.Log(ExpTable.GetNumGrothTypes());
-
-    }
-    public void Start()
-    {
-        SnapPositionToGrid(transform.position);
-    }
-
-    public void SnapPositionToGrid(Vector3 position)
-    {
-        animator.SetBool("IsMoving", isMoving);
-
-        while (!IsWakable(position))
-        {
-            --position.x;
-            --position.y;
+            HandleUpdate();
 
         }
 
-        position.x = Mathf.Floor(position.x) + .5f;
-        position.y = Mathf.Floor(position.y) + .5f + offset;
-        transform.position = position;
-    }
-
-
-    public void OnEnable()
-    {
-        if (GameManager.Instance != null && GameManager.Instance.IsBattleAScene)
+        public void HandleUpdate()
         {
-            var d = GameManager.Instance.BattleSceneData.RetriveDirection();
-            animator.SetFloat("Horizontal", d.x);
-            animator.SetFloat("Vertical", d.y);
+            if (Keyboard.current.qKey.wasPressedThisFrame)
+                Application.Quit();
 
-            transform.position = GameManager.Instance.BattleSceneData.ReturnPosition();
-            GameManager.Instance.BattleSceneData.SetPlayerCharSprite(battleSprite);
+            if (GameManager.Instance.State == GameState.Paused)
+            {
+                isMoving = false;
+                isRunning = false;
 
-        }
-        inputActions.PlayerDigital.Enable();
+                return;
+            }
+
+            movement = inputActions.PlayerDigital.Move.ReadValue<Vector2>();
+            isRunning = inputActions.PlayerDigital.Run.ReadValue<float>() != 0;
+
+            if (inputActions.PlayerDigital.Interact.triggered)
+                StartCoroutine(InteractWith_CR());
+
+            //if (Keyboard.current.mKey.wasPressedThisFrame)
+            //  InputMode();
+            #region Legacy
+            /*
+            if (Input.GetKeyUp(KeyCode.Z))
+                isNorm = !isNorm;
+            if (doLegacyInput)
+            {
+
+                if (!isMoving)
+                {
 
 
-    }
+                    //change input sistem
+                    //movement.x = Input.GetAxisRaw("Horizontal") ;
+                    //movement.y = Input.GetAxisRaw("Vertical") ;
 
-    // Update is called once per frame
-    void Update()
-    {
-        HandleUpdate();
+                    if (movement != Vector2.zero)
+                    {
+                        var targetPos = transform.position;
+                        targetPos.x += movement.x;
+                        targetPos.y += movement.y;
 
-    }
+                        StartCoroutine(Move(targetPos));
+                    }
 
-    public void HandleUpdate()
-    {
-        if (Keyboard.current.qKey.wasPressedThisFrame)
-            Application.Quit();
+                    // ang = Mathf.Atan2(  movement.y, movement.x);
+                }
+            }
+             */
 
-        if (GameManager.Instance.State == GameState.Paused)
-        {
-            isMoving = false;
-            isRunning = false;
-
-            return;
-        }
-
-        movement = inputActions.PlayerDigital.Move.ReadValue<Vector2>();
-        isRunning = inputActions.PlayerDigital.Run.ReadValue<float>() != 0;
-
-        if (inputActions.PlayerDigital.Interact.triggered)
-            StartCoroutine(InteractWith_CR());
-
-        //if (Keyboard.current.mKey.wasPressedThisFrame)
-        //  InputMode();
-        #region Legacy
-        /*
-        if (Input.GetKeyUp(KeyCode.Z))
-            isNorm = !isNorm;
-        if (doLegacyInput)
-        {
+            #endregion
 
             if (!isMoving)
             {
 
+                Vector2 adjMove;
+                //adjMove = movement.normalized;
+                adjMove = movement;
+                //Debug.Log(adjMove);
 
-                //change input sistem
-                //movement.x = Input.GetAxisRaw("Horizontal") ;
-                //movement.y = Input.GetAxisRaw("Vertical") ;
+                if (adjMove.y != 0) adjMove.x = 0;
 
                 if (movement != Vector2.zero)
                 {
-                    var targetPos = transform.position;
-                    targetPos.x += movement.x;
-                    targetPos.y += movement.y;
+                    animator.SetFloat("Horizontal", adjMove.x);
+                    animator.SetFloat("Vertical", adjMove.y);
 
-                    StartCoroutine(Move(targetPos));
+
+                    var targetPos = transform.position;
+                    targetPos.x += Mathf.Round(adjMove.x);
+                    targetPos.y += Mathf.Round(adjMove.y);
+
+                    if (IsWakable(targetPos) && inputActions.PlayerDigital.Move.phase == InputActionPhase.Performed)
+                        StartCoroutine(Move_CR(targetPos));
                 }
 
-                // ang = Mathf.Atan2(  movement.y, movement.x);
+                animator.SetBool("IsMoving", isMoving);
+                animator.SetBool("IsRunning", isRunning);
             }
+            //InteractWith();
+
+            //UpdateAnimation();
         }
-         */
 
-        #endregion
 
-        if (!isMoving)
+        public IEnumerator Move_CR(Vector3 targetPos)
         {
+            isMoving = true;
 
-            Vector2 adjMove;
-            //adjMove = movement.normalized;
-            adjMove = movement;
-            //Debug.Log(adjMove);
+            /*
+            Collider2D tile = Physics2D.OverlapCircle(targetPos, 0.185f, LayersManager.i.PortalLayer);
+            if (tile != null && tile.TryGetComponent<Portal>(out Portal p))
+                yield return p.OnLook(this);
+            */
+            //var speed = 0f;
 
-            if (adjMove.y != 0) adjMove.x = 0;
-
-            if (movement != Vector2.zero)
+            //UpdateAnimation();
+            while ((targetPos - transform.position).sqrMagnitude > Mathf.Epsilon)
             {
-                animator.SetFloat("Horizontal", adjMove.x);
-                animator.SetFloat("Vertical", adjMove.y);
+                var speed = (isRunning) ? runSpeed : moveSpeed;
+                //var change = (movement != Vector2.zero) ? 1 : -1; 
+                //speed =  Mathf.Clamp(speed +(change * maxSpeed) / 50f, 0, maxSpeed);
 
 
-                var targetPos = transform.position;
-                targetPos.x += Mathf.Round(adjMove.x);
-                targetPos.y += Mathf.Round(adjMove.y);
+                transform.position = Vector3.MoveTowards(transform.position, targetPos, speed * Time.deltaTime);
+                // animator.SetFloat("Speed", movement.sqrMagnitude);
+                yield return null;
 
-                if (IsWakable(targetPos) && inputActions.PlayerDigital.Move.phase == InputActionPhase.Performed)
-                    StartCoroutine(Move_CR(targetPos));
             }
 
-            animator.SetBool("IsMoving", isMoving);
-            animator.SetBool("IsRunning", isRunning);
-        }
-        //InteractWith();
+            //UpdateAnimation();
+            //animator.SetFloat("Speed", movement.normalized.sqrMagnitude);
 
-        //UpdateAnimation();
-    }
+            transform.position = targetPos;
+
+            OnMoveOverTrigger();
+            isMoving = false;
+            // if (movement == Vector2.zero)
+            //   speed = 0f;
 
 
-    public IEnumerator Move_CR(Vector3 targetPos)
-    {
-        isMoving = true;
-
-        /*
-        Collider2D tile = Physics2D.OverlapCircle(targetPos, 0.185f, LayersManager.i.PortalLayer);
-        if (tile != null && tile.TryGetComponent<Portal>(out Portal p))
-            yield return p.OnLook(this);
-        */
-        //var speed = 0f;
-
-        //UpdateAnimation();
-        while ((targetPos - transform.position).sqrMagnitude > Mathf.Epsilon)
-        {
-            var speed = (isRunning) ? runSpeed : moveSpeed;
-            //var change = (movement != Vector2.zero) ? 1 : -1; 
-            //speed =  Mathf.Clamp(speed +(change * maxSpeed) / 50f, 0, maxSpeed);
-            
-
-            transform.position = Vector3.MoveTowards(transform.position, targetPos, speed * Time.deltaTime);
-            // animator.SetFloat("Speed", movement.sqrMagnitude);
-            yield return null;
 
         }
 
-        //UpdateAnimation();
-        //animator.SetFloat("Speed", movement.normalized.sqrMagnitude);
-
-        transform.position = targetPos;
-
-        OnMoveOverTrigger();
-        isMoving = false;
-       // if (movement == Vector2.zero)
-         //   speed = 0f;
-
-
-
-    }
-
-    void OnMoveOverTrigger()
-    {
-        var triggers = Physics2D.OverlapCircleAll(transform.position + new Vector3(0, .3f), 0.3f, LayersManager.i.TriggerableLayers);
-        foreach (var t in triggers)
+        void OnMoveOverTrigger()
         {
-            if (t.TryGetComponent<ITriggerable>(out var trigger))
+            var triggers = Physics2D.OverlapCircleAll(transform.position + new Vector3(0, .3f), 0.3f, LayersManager.i.TriggerableLayers);
+            foreach (var t in triggers)
             {
-                trigger.OnContact(this);
-                break;
+                if (t.TryGetComponent<ITriggerable>(out var trigger))
+                {
+                    trigger.OnContact(this);
+                    break;
+                }
             }
         }
-    }
 
 
 
 
 
-    bool IsWakable(Vector3 position)
-    {
-        if (Physics2D.OverlapCircle(position, 0.185f, LayersManager.i.Unwalkable | LayersManager.i.Interactable) != null)
-            return false;
-
-
-        Collider2D tile = Physics2D.OverlapCircle(position, 0.185f, LayersManager.i.PortalLayer);
-        if (tile != null && tile.TryGetComponent<IPortal>(out var p))
-            StartCoroutine(p.OnLook_CR(this));
-
-
-        return true;
-    }
-
-    IEnumerator InteractWith_CR()
-    {
-        //inputActions.PlayerDigital.Move.Disable();
-        Vector2 pos = (Vector2)transform.position + new Vector2(animator.GetFloat("Horizontal"), animator.GetFloat("Vertical"));
-        var i = Physics2D.OverlapCircle(pos, .01f, LayersManager.i.Interactable);
-        //var i = Physics2D.OverlapCircle(pos, .01f);
-        if (GameManager.Instance.State == GameState.freeRoam && i != null && i.TryGetComponent<IInteractable>(out var p))
+        bool IsWakable(Vector3 position)
         {
-            yield return (p.Interact_CR(transform));
+            if (Physics2D.OverlapCircle(position, 0.185f, LayersManager.i.Unwalkable | LayersManager.i.Interactable) != null)
+                return false;
+
+
+            Collider2D tile = Physics2D.OverlapCircle(position, 0.185f, LayersManager.i.PortalLayer);
+            if (tile != null && tile.TryGetComponent<IPortal>(out var p))
+                StartCoroutine(p.OnLook_CR(this));
+
+
+            return true;
         }
 
-    }
-
-    public Vector2 GetDirection() => movement;
-
-    public object CaptureState()
-    {
-        var saveData = new PlayerSaveData()
+        IEnumerator InteractWith_CR()
         {
-            position = new float[] { transform.position.x, transform.position.y, transform.position.z },
-            direction = new float[] { animator.GetFloat("Horizontal"), animator.GetFloat("Vertical") },
-            party = GetComponent<PokemonParty>().GetFullParty().Select(p => p.GetSaveData()).ToList(),
+            //inputActions.PlayerDigital.Move.Disable();
+            Vector2 pos = (Vector2)transform.position + new Vector2(animator.GetFloat("Horizontal"), animator.GetFloat("Vertical"));
+            var i = Physics2D.OverlapCircle(pos, .01f, LayersManager.i.Interactable);
+            //var i = Physics2D.OverlapCircle(pos, .01f);
+            if (GameManager.Instance.State == GameState.freeRoam && i != null && i.TryGetComponent<IInteractable>(out var p))
+            {
+                yield return (p.Interact_CR(transform));
+            }
 
-        };
+        }
 
-        return saveData;
+        public Vector2 GetDirection() => movement;
 
+        public object CaptureState()
+        {
+            var saveData = new PlayerSaveData()
+            {
+                position = new float[] { transform.position.x, transform.position.y, transform.position.z },
+                direction = new float[] { animator.GetFloat("Horizontal"), animator.GetFloat("Vertical") },
+                party = GetComponent<PokemonParty>().GetFullParty().Select(p => p.GetSaveData()).ToList(),
+
+            };
+
+            return saveData;
+
+        }
+
+        public void RestoreState(object state)
+        {
+            var saveData = (PlayerSaveData)state;
+
+            var pos = saveData.position;
+            transform.position = new Vector3(pos[0], pos[1], pos[2]);
+            var dir = saveData.direction;
+            animator.SetFloat("Horizontal", dir[0]);
+            animator.SetFloat("Vertical", dir[1]);
+
+            GetComponent<PokemonParty>().Party = saveData.party.Select(p => new Pokemon(p)).ToList();
+
+
+        }
     }
 
-    public void RestoreState(object state)
+    [Serializable]
+    public class PlayerSaveData
     {
-        var saveData = (PlayerSaveData)state;
-
-        var pos = saveData.position;
-        transform.position = new Vector3(pos[0], pos[1], pos[2]);
-        var dir = saveData.direction;
-        animator.SetFloat("Horizontal", dir[0]);
-        animator.SetFloat("Vertical", dir[1]);
-
-        GetComponent<PokemonParty>().Party = saveData.party.Select(p => new Pokemon(p)).ToList();
-
-
+        public float[] position;
+        public float[] direction;
+        public List<PokemonSaveData> party;
     }
-}
 
-[Serializable]
-public class PlayerSaveData
-{
-    public float[] position;
-    public float[] direction;
-    public List<PokemonSaveData> party;
 }

--- a/Controllers/TrainerController.cs
+++ b/Controllers/TrainerController.cs
@@ -2,182 +2,261 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using pokeCopy;
-[RequireComponent(typeof(PokemonParty))]
-public class TrainerController : MonoBehaviour, IInteractable, ISavable, INamable
+
+namespace pokeCopy
 {
-    [SerializeField] private TrainerClass trainerClass;
-    [SerializeField] private string trainerName;
-    [SerializeField] private Sprite trainerChar;
 
-    public string Name 
-    { 
-        get => trainerClass.ToString().Replace("Jr_", "Jr. ").Replace("_n_", " & ").Replace('_',' ') + " " + trainerName;
-    }
-
-
-    public Sprite TrainerChar { get => trainerChar; }
-    [SerializeField] TrainerData data;
-    [SerializeField] GameObject exclamation;
-    [SerializeField] CharMovement movement;
-    [SerializeField] NPCMovement behave;
-    [SerializeField] Direction startingDirection;
-    Vector2[] startingPos;
-    [SerializeField] Dialogue dialogue;
-    [SerializeField] Dialogue defeatDialogue;
-    [SerializeField] GameObject fov;
-    [SerializeField] PokemonTeam team;
-    [SerializeField] PokemonParty pokeParty;
-
-    public PokemonParty PokeParty { get => pokeParty; }
-
-    Vector3 rot;
-
-    [SerializeField] bool battleLost = false;
-
-    public void Awake()
+    [RequireComponent(typeof(PokemonParty))]
+    public class TrainerController : MonoBehaviour, IInteractable, ISavable, INamable
     {
-        startingPos = new Vector2[4] { Vector2.up, Vector2.down, Vector2.left, Vector2.right };//use dictionary?
-        rot = new Vector3(0, 0, 90);
-        team.Init();
-        //No Need to do this more than unce
-        data.SetData(Name, GetComponent<PokemonParty>(), trainerChar, team);
-        //battleLost = data.GetBattleResult();
-    }
-    // Start is called before the first frame update
-    void Start()
-    {
-        movement = GetComponent<CharMovement>();
-        movement.animator.SetFloat("Horizontal", Mathf.Clamp(startingPos[(int)startingDirection].x, -1, 1));
-        movement.animator.SetFloat("Vertical", Mathf.Clamp(startingPos[(int)startingDirection].y, -1, 1));
-        pokeParty = GetComponent<PokemonParty>();
-        /*
-        if (battleLost)
-            BattleResultHandler();
-        */
-        //data.Awake();
-        AdjustFOV();
-    }
+        [SerializeField] private TrainerClass trainerClass;
+        [SerializeField] private string trainerName;
+        [SerializeField] private Sprite trainerChar;
 
-    // Update is called once per frame
-    void Update()
-    {
-
-        if (movement.IsMoving)
-            AdjustFOV();
-    }
-
-    void AdjustFOV()
-    {
-        //if instead: use vector2.angle(
-        //rot.z = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg + 90;
-        //var fovPos = new Vector2(transform.position.x + dir.x, transform.position.y + dir.y);
-        var dir = new Vector3(movement.animator.GetFloat("Horizontal"), movement.animator.GetFloat("Vertical"));
-        var fovPos = new Vector2(transform.position.x, transform.position.y + 0.3f);
-
-        rot.z = Vector2.SignedAngle(Vector2.down, dir);
-        fov.transform.SetPositionAndRotation(fovPos, Quaternion.Euler(rot));
-
-    }
-
-    public void BattleResultHandler()
-    {
-
-        battleLost = data.GetBattleResult();
-        if (battleLost)
-            fov.SetActive(false);
-        GameManager.Instance.OnBattleEnd -= BattleResultHandler;
-    }
-
-
-    public void GetBattleResult(bool result)
-    {
-        battleLost = result;
-        if (battleLost)
-            fov.SetActive(false);
-    }
-
-    public IEnumerator TriggerBattle_CR(PlayerMovement player = null)//passing player allows for referencing without the need for a raycast
-    {
-        //behave.enabled = false;
-        if (battleLost)
-            yield break;
-
-        exclamation.SetActive(true);
-        yield return new WaitForSeconds(.5f);
-        exclamation.SetActive(false);
-
-        if (player != null)
+        public string Name
         {
-            var foePos = player.transform.position;
-            var diff = foePos - transform.position;
+            get => trainerClass.ToString().Replace("Jr_", "Jr. ").Replace("_n_", " & ").Replace('_', ' ') + " " + trainerName;
+        }
 
-            var moveVec = diff - diff.normalized;
-            moveVec = new Vector2(Mathf.Round(moveVec.x), Mathf.Round(moveVec.y));
 
-            yield return movement.Move(moveVec);
-            yield return DialogueCacheManager.I.ShowDialogue_CR(dialogue);
+        public Sprite TrainerChar { get => trainerChar; }
+        [SerializeField] TrainerData data;
+        [SerializeField] GameObject exclamation;
+        [SerializeField] CharMovement movement;
+        [SerializeField] NPCMovement behave;
+        [SerializeField] Direction startingDirection;
+        Vector2[] startingPos;
+        [SerializeField] Dialogue dialogue;
+        [SerializeField] Dialogue defeatDialogue;
+        [SerializeField] GameObject fov;
+        [SerializeField] PokemonTeam team;
+        [SerializeField] PokemonParty pokeParty;
 
-            GameManager.Instance.StartTrainerBattle(this);
+        public PokemonParty PokeParty { get => pokeParty; }
 
+        Vector3 rot;
+
+        [SerializeField] bool battleLost = false;
+
+        public void Awake()
+        {
+            startingPos = new Vector2[4] { Vector2.up, Vector2.down, Vector2.left, Vector2.right };//use dictionary?
+            rot = new Vector3(0, 0, 90);
+            team.Init();
+            //No Need to do this more than unce
+            data.SetData(Name, GetComponent<PokemonParty>(), trainerChar, team);
+            //battleLost = data.GetBattleResult();
+        }
+        // Start is called before the first frame update
+        void Start()
+        {
+            movement = GetComponent<CharMovement>();
+            movement.animator.SetFloat("Horizontal", Mathf.Clamp(startingPos[(int)startingDirection].x, -1, 1));
+            movement.animator.SetFloat("Vertical", Mathf.Clamp(startingPos[(int)startingDirection].y, -1, 1));
+            pokeParty = GetComponent<PokemonParty>();
+            /*
+            if (battleLost)
+                BattleResultHandler();
+            */
+            //data.Awake();
+            AdjustFOV();
+        }
+
+        // Update is called once per frame
+        void Update()
+        {
+
+            if (movement.IsMoving)
+                AdjustFOV();
+        }
+
+        void AdjustFOV()
+        {
+            //if instead: use vector2.angle(
+            //rot.z = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg + 90;
+            //var fovPos = new Vector2(transform.position.x + dir.x, transform.position.y + dir.y);
+            var dir = new Vector3(movement.animator.GetFloat("Horizontal"), movement.animator.GetFloat("Vertical"));
+            var fovPos = new Vector2(transform.position.x, transform.position.y + 0.3f);
+
+            rot.z = Vector2.SignedAngle(Vector2.down, dir);
+            fov.transform.SetPositionAndRotation(fovPos, Quaternion.Euler(rot));
 
         }
-        //yield return new WaitWhile(() => GameManager.Instance.State == GameState.Battle);
-        //Debug.Log("UPdate trainer");
-        //battleLost = data.GetBattleResult();
 
-    }
-
-    /*
-    public IEnumerator TriggerBattleOld(PlayerMovement player = null)//passing player allows for referencing without the need for a raycast
-    {
-        //behave.enabled = false;
-        if (battleLost)
-            yield break;
-
-        exclamation.SetActive(true);
-        yield return new WaitForSeconds(.5f);
-        exclamation.SetActive(false);
-
-        if (player != null)
+        public void BattleResultHandler()
         {
-            var foePos = player.transform.position;
-            var diff = foePos - transform.position;
 
-            var moveVec = diff - diff.normalized;
-            moveVec = new Vector2(Mathf.Round(moveVec.x), Mathf.Round(moveVec.y));
+            battleLost = data.GetBattleResult();
+            if (battleLost)
+                fov.SetActive(false);
+            GameManager.Instance.OnBattleEnd -= BattleResultHandler;
+        }
 
-            yield return movement.Move(moveVec);
-            DialogueCacheManager.I.StartDialogue(dialogue, () =>
+
+        public void GetBattleResult(bool result)
+        {
+            battleLost = result;
+            if (battleLost)
+                fov.SetActive(false);
+        }
+
+        public IEnumerator TriggerBattle_CR(PlayerMovement player = null)//passing player allows for referencing without the need for a raycast
+        {
+            //behave.enabled = false;
+            if (battleLost)
+                yield break;
+
+            exclamation.SetActive(true);
+            yield return new WaitForSeconds(.5f);
+            exclamation.SetActive(false);
+
+            if (player != null)
             {
-                if (GameManager.Instance.IsBattleAScene)
+                var foePos = player.transform.position;
+                var diff = foePos - transform.position;
+
+                var moveVec = diff - diff.normalized;
+                moveVec = new Vector2(Mathf.Round(moveVec.x), Mathf.Round(moveVec.y));
+
+                yield return movement.Move(moveVec);
+                yield return DialogueCacheManager.I.ShowDialogue_CR(dialogue);
+
+                GameManager.Instance.StartTrainerBattle(this);
+
+
+            }
+            //yield return new WaitWhile(() => GameManager.Instance.State == GameState.Battle);
+            //Debug.Log("UPdate trainer");
+            //battleLost = data.GetBattleResult();
+
+        }
+
+        /*
+        public IEnumerator TriggerBattleOld(PlayerMovement player = null)//passing player allows for referencing without the need for a raycast
+        {
+            //behave.enabled = false;
+            if (battleLost)
+                yield break;
+
+            exclamation.SetActive(true);
+            yield return new WaitForSeconds(.5f);
+            exclamation.SetActive(false);
+
+            if (player != null)
+            {
+                var foePos = player.transform.position;
+                var diff = foePos - transform.position;
+
+                var moveVec = diff - diff.normalized;
+                moveVec = new Vector2(Mathf.Round(moveVec.x), Mathf.Round(moveVec.y));
+
+                yield return movement.Move(moveVec);
+                DialogueCacheManager.I.StartDialogue(dialogue, () =>
                 {
-                    GameManager.Instance.OnBattleEnd += BattleResultHandler;
-                    GameManager.Instance.StartTrainerBattleScene(data);
+                    if (GameManager.Instance.IsBattleAScene)
+                    {
+                        GameManager.Instance.OnBattleEnd += BattleResultHandler;
+                        GameManager.Instance.StartTrainerBattleScene(data);
+
+                    }
+                    else
+                    {
+                        GameManager.Instance.StartTrainerBattle(this);
+                    }
+                }
+                );
+
+
+            }
+            /*
+            else
+            {
+                var dir = new Vector3(movement.animator.GetFloat("Horizontal"), movement.animator.GetFloat("Vertical"));
+
+                var detected = Physics2D.Raycast(transform.position + dir, dir, 5, LayersManager.i.PlayerLayer);
+                if (detected)
+                {
+                    var diff = (detected.transform.position - transform.position);
+                    Debug.Log(diff);
+                    var movVec = diff - diff.normalized;
+                    Debug.Log(movVec);
+                    movVec = new Vector2(Mathf.Round(movVec.x), Mathf.Round(movVec.y));
+                    yield return movement.Move(movVec);
+                    DialogueCacheManager.I.StartDialogue(dialogue, () =>
+                    {
+                        if (GameManager.Instance.IsBattleAScene)
+                        {
+                            GameManager.Instance.OnBattleEnd += BattleResultHandler;
+                            GameManager.Instance.StartTrainerBattleScene(data);
+
+                        }
+                        else
+                        {
+                            GameManager.Instance.StartTrainerBattle(this);
+                        }
+                    });
 
                 }
-                else
+            }
+            //Why this does not working?
+            yield return new WaitUntil(() => GameManager.Instance.State == GameState.freeRoam);
+            Debug.Log("UPdate trainer");
+            battleLost = data.GetBattleResult();
+
+        }
+            */
+
+        public IEnumerator Interact_CR(Transform initiator) //reeavaluete
+        {
+
+
+            movement.LookTowrds(initiator.position);
+            if (!battleLost)
+            {
+                yield return DialogueCacheManager.I.ShowDialogue_CR(dialogue);
+                /*
+                DialogueCacheManager.I.StartDialogue(dialogue, () =>
                 {
                     GameManager.Instance.StartTrainerBattle(this);
                 }
+                );
+                */
+                GameManager.Instance.StartTrainerBattle(this);
             }
-            );
-
-
-        }
-        /*
-        else
-        {
-            var dir = new Vector3(movement.animator.GetFloat("Horizontal"), movement.animator.GetFloat("Vertical"));
-
-            var detected = Physics2D.Raycast(transform.position + dir, dir, 5, LayersManager.i.PlayerLayer);
-            if (detected)
+            else
             {
-                var diff = (detected.transform.position - transform.position);
-                Debug.Log(diff);
-                var movVec = diff - diff.normalized;
-                Debug.Log(movVec);
-                movVec = new Vector2(Mathf.Round(movVec.x), Mathf.Round(movVec.y));
-                yield return movement.Move(movVec);
+                //DialogueCacheManager.I.StartDialogue(defeatDialogue);
+                yield return DialogueCacheManager.I.ShowDialogue_CR(defeatDialogue);
+            }
+
+
+            yield return null;
+        }
+
+        public object CaptureState()
+        {
+            return battleLost;
+        }
+
+        public void RestoreState(object state)
+        {
+            battleLost = (bool)state;
+
+            if (battleLost)
+                fov.SetActive(false);
+        }
+
+        /*
+        public void InteractOld(Transform initiator = null)
+        {
+
+            Debug.LogWarning("Interact");
+
+            movement.LookTowrds(initiator.position);
+            Debug.LogWarning("moveTowrds");
+            if (!battleLost)
+            {
+
                 DialogueCacheManager.I.StartDialogue(dialogue, () =>
                 {
                     if (GameManager.Instance.IsBattleAScene)
@@ -191,158 +270,85 @@ public class TrainerController : MonoBehaviour, IInteractable, ISavable, INamabl
                         GameManager.Instance.StartTrainerBattle(this);
                     }
                 });
-
             }
-        }
-        //Why this does not working?
-        yield return new WaitUntil(() => GameManager.Instance.State == GameState.freeRoam);
-        Debug.Log("UPdate trainer");
-        battleLost = data.GetBattleResult();
+            else
+            {
+                Debug.LogWarning("Start dialogue");
+                DialogueCacheManager.I.StartDialogue(defeatDialogue);
+            }
 
-    }
+        }
+
         */
 
-    public IEnumerator Interact_CR(Transform initiator) //reeavaluete
-    {
-
-
-        movement.LookTowrds(initiator.position);
-        if (!battleLost)
-        {
-            yield return DialogueCacheManager.I.ShowDialogue_CR(dialogue);
-            /*
-            DialogueCacheManager.I.StartDialogue(dialogue, () =>
-            {
-                GameManager.Instance.StartTrainerBattle(this);
-            }
-            );
-            */
-            GameManager.Instance.StartTrainerBattle(this);
-        }
-        else
-        {
-            //DialogueCacheManager.I.StartDialogue(defeatDialogue);
-            yield return DialogueCacheManager.I.ShowDialogue_CR(defeatDialogue);
-        }
-
-
-        yield return null;
     }
 
-    public object CaptureState()
+
+    public enum Direction
     {
-        return battleLost;
+        up, down, left, right,
     }
 
-    public void RestoreState(object state)
+    public enum TrainerClass
     {
-        battleLost = (bool)state;
-
-        if (battleLost)
-            fov.SetActive(false);
-    }
-
-    /*
-    public void InteractOld(Transform initiator = null)
-    {
-
-        Debug.LogWarning("Interact");
-
-        movement.LookTowrds(initiator.position);
-        Debug.LogWarning("moveTowrds");
-        if (!battleLost)
-        {
-
-            DialogueCacheManager.I.StartDialogue(dialogue, () =>
-            {
-                if (GameManager.Instance.IsBattleAScene)
-                {
-                    GameManager.Instance.OnBattleEnd += BattleResultHandler;
-                    GameManager.Instance.StartTrainerBattleScene(data);
-
-                }
-                else
-                {
-                    GameManager.Instance.StartTrainerBattle(this);
-                }
-            });
-        }
-        else
-        {
-            Debug.LogWarning("Start dialogue");
-            DialogueCacheManager.I.StartDialogue(defeatDialogue);
-        }
+        Artist,
+        Belle_n_Pa,
+        Cameraman,
+        Clown,
+        Commander,
+        Cowgirl,
+        Cyclist,
+        Double_Team,
+        Galactic_Grunt,
+        Galactic_Boss,
+        Idol,
+        Jogger,
+        PokéKid,
+        Rancher,
+        Reporter,
+        Socialite,
+        Veteran,
+        Waiter,
+        Waitress,
+        Beauty,
+        Biker,
+        Bird_Keeper,
+        Blackbelt,
+        Boss,
+        Bug_Catcher,
+        Burglar,
+        Champion,
+        Channeler,
+        Cool_Trainer,
+        Cue_Ball,
+        Elite_Four,
+        Engineer,
+        Fisherman,
+        Gambler,
+        Gentleman,
+        Hiker,
+        Jr_TrainerM,
+        Jr_TrainerF,
+        Juggler,
+        Lass,
+        Leader,
+        PokéManiac,
+        Psychic,
+        Rival,
+        Rocker,
+        Rocket,
+        Sailor,
+        Scientist,
+        Super_Nerd,
+        Swimmer,
+        Tamer,
+        Youngster,
 
     }
 
-    */
+
 
 }
-
-
-public enum Direction
-{
-    up, down, left, right,
-}
-
-public enum TrainerClass
-{
-    Artist,
-    Belle_n_Pa,
-    Cameraman,
-    Clown,
-    Commander,
-    Cowgirl,
-    Cyclist,
-    Double_Team,
-    Galactic_Grunt,
-    Galactic_Boss,
-    Idol,
-    Jogger,
-    PokéKid,
-    Rancher,
-    Reporter,
-    Socialite,
-    Veteran,
-    Waiter,
-    Waitress,
-    Beauty,
-    Biker,
-    Bird_Keeper,
-    Blackbelt,
-    Boss,
-    Bug_Catcher,
-    Burglar,
-    Champion,
-    Channeler,
-    Cool_Trainer,
-    Cue_Ball,
-    Elite_Four,
-    Engineer,
-    Fisherman,
-    Gambler,
-    Gentleman,
-    Hiker,
-    Jr_TrainerM,
-    Jr_TrainerF,
-    Juggler,
-    Lass,
-    Leader,
-    PokéManiac,
-    Psychic,
-    Rival,
-    Rocker,
-    Rocket,
-    Sailor,
-    Scientist,
-    Super_Nerd,
-    Swimmer,
-    Tamer,
-    Youngster,
-
-}
-
-
 
 
 

--- a/DataManagers/MapData.cs
+++ b/DataManagers/MapData.cs
@@ -3,15 +3,21 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-[CreateAssetMenu (fileName = "New MapData", menuName = "MapData/ Create new MapData")]
-public class MapData : ScriptableObject
+
+namespace pokeCopy
 {
-    [SerializeField] List<Pokemon> wildPokemons;
-    [SerializeField] List<MapData> mapConections;
-    [SerializeField] Scene scenes;
+
+    [CreateAssetMenu(fileName = "New MapData", menuName = "MapData/ Create new MapData")]
+    public class MapData : ScriptableObject
+    {
+        [SerializeField] List<Pokemon> wildPokemons;
+        [SerializeField] List<MapData> mapConections;
+        [SerializeField] Scene scenes;
 
 
-    public List<Pokemon> WildPokemons { get => wildPokemons; }
+        public List<Pokemon> WildPokemons { get => wildPokemons; }
 
 
+    }
 }
+

--- a/DataManagers/SceneData.cs
+++ b/DataManagers/SceneData.cs
@@ -2,129 +2,134 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-[CreateAssetMenu(fileName = "SceneData", menuName = "SceneData/New SceneData")]
-public class SceneData : ScriptableObject
+
+namespace pokeCopy
 {
-    //TO BE CLEANED
-    bool loaded;
-    public bool Loaded { get { return loaded; } private set { } }
-    Vector3 playerPosition;
-    Vector2 direction;
-    Transform trannsformData;
-    PokemonParty playerParty;
-    PokemonParty trainerParty;
-    Pokemon wildPkmn;
 
-    public Sprite PlayerChar { get; private set; }
-    public Sprite TrainerChar { get; private set; }
-
-    TrainerController trainer;
-    TrainerData trainerData;
-
-    public void ClearData()
+    [CreateAssetMenu(fileName = "SceneData", menuName = "SceneData/New SceneData")]
+    public class SceneData : ScriptableObject
     {
-        playerParty = null;
-        trainerData = null;
-        TrainerChar = null;
-    }
+        //TO BE CLEANED
+        bool loaded;
+        public bool Loaded { get { return loaded; } private set { } }
+        Vector3 playerPosition;
+        Vector2 direction;
+        Transform trannsformData;
+        PokemonParty playerParty;
+        PokemonParty trainerParty;
+        Pokemon wildPkmn;
 
-    public void GetPosition(Vector3 position)
-    {
-        loaded = true;
-        playerPosition = position;
-    }
+        public Sprite PlayerChar { get; private set; }
+        public Sprite TrainerChar { get; private set; }
 
-    public void ReceivePositionData(Transform transform)
-    {
-        trannsformData = transform;
-    }
+        TrainerController trainer;
+        TrainerData trainerData;
 
-    public void PassDirection(Vector2 d)
-    {
-        direction = d;
-    }
-
-    public void LoadParty(PokemonParty party)
-    {
-        playerParty = party;
-    }
-
-    public void LoadWilPkmn(Pokemon wild)
-    {
-        wildPkmn = wild;
-    }
-
-    public Vector3 ReturnPosition()
-    {
-        if (loaded)
+        public void ClearData()
         {
-            loaded = false;
-            return playerPosition;
+            playerParty = null;
+            trainerData = null;
+            TrainerChar = null;
+        }
+
+        public void GetPosition(Vector3 position)
+        {
+            loaded = true;
+            playerPosition = position;
+        }
+
+        public void ReceivePositionData(Transform transform)
+        {
+            trannsformData = transform;
+        }
+
+        public void PassDirection(Vector2 d)
+        {
+            direction = d;
+        }
+
+        public void LoadParty(PokemonParty party)
+        {
+            playerParty = party;
+        }
+
+        public void LoadWilPkmn(Pokemon wild)
+        {
+            wildPkmn = wild;
+        }
+
+        public Vector3 ReturnPosition()
+        {
+            if (loaded)
+            {
+                loaded = false;
+                return playerPosition;
+
+            }
+            else
+                return Vector3.zero;
 
         }
-        else
-            return Vector3.zero;
 
-    }
+        public Vector2 RetriveDirection()
+        {
+            return direction;
+        }
 
-    public Vector2 RetriveDirection()
-    {
-        return direction;
-    }
+        public PokemonParty RetrivePlayerParty()
+        {
+            return playerParty ? playerParty : null;
+        }
 
-    public PokemonParty RetrivePlayerParty()
-    {
-        return playerParty ? playerParty: null;
-    }
+        public PokemonParty RetriveTrainerParty()
+        {
+            return trainerParty ? trainerParty : null;
+        }
+        public void ReceiveBattleData(PokemonParty party, Pokemon wild)
+        {
+            playerParty = party;
+            wildPkmn = wild;
 
-    public PokemonParty RetriveTrainerParty()
-    {
-        return trainerParty ? trainerParty : null;
-    }
-    public void ReceiveBattleData(PokemonParty party, Pokemon wild)
-    {
-        playerParty = party;
-        wildPkmn = wild;
+        }
 
-    }
+        public void ReceiveBattleData(PokemonParty party, PokemonParty trainer)
+        {
+            playerParty = party;
+            trainerParty = trainer;
+        }
 
-    public void ReceiveBattleData(PokemonParty party, PokemonParty trainer)
-    {
-        playerParty = party;
-        trainerParty = trainer;
-    }
+        public Pokemon RetriveWildPkmn()
+        {
+            return wildPkmn;
+        }
 
-    public Pokemon RetriveWildPkmn()
-    {
-        return wildPkmn;
-    }
+        public void SetPlayerCharSprite(Sprite playerchar)
+        {
+            PlayerChar = playerchar;
+        }
 
-    public void SetPlayerCharSprite(Sprite playerchar)
-    {
-        PlayerChar = playerchar;
-    }
+        public void SetTrainerSprite(Sprite trainerSprite)
+        {
+            TrainerChar = trainerSprite;
+        }
 
-    public void SetTrainerSprite(Sprite trainerSprite)
-    {
-        TrainerChar = trainerSprite;
-    }
+        public void GetTrainerData(TrainerController trainer)
+        {
+            this.trainer = trainer;
+        }
 
-    public void GetTrainerData(TrainerController trainer)
-    {
-        this.trainer = trainer;
-    }
+        public void GetTrainerData(TrainerData trainer)
+        {
+            this.trainerData = trainer;
+        }
 
-    public void GetTrainerData(TrainerData trainer)
-    {
-        this.trainerData = trainer;
-    }
-
-    public TrainerController RetriveTrainer()
-    {
-        return trainer;
-    }
-    public TrainerData RetriveTrainerData()
-    {
-        return trainerData;
+        public TrainerController RetriveTrainer()
+        {
+            return trainer;
+        }
+        public TrainerData RetriveTrainerData()
+        {
+            return trainerData;
+        }
     }
 }

--- a/DataManagers/UIColors.cs
+++ b/DataManagers/UIColors.cs
@@ -3,80 +3,82 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
-[CreateAssetMenu(fileName = "UIColors", menuName = "")]
-public class UIColors : ScriptableObject//make Static?
+namespace pokeCopy
 {
-    [Header ("Status colors")]
-    public Color psnColor;
-    public Color brnColor;
-    public Color parColor;
-    public Color frzColor;
-    public Color slpColor;
-    public Color fntColor;
-    [Space]
-    [Header ("Type Icons")]
-    public Sprite none;
-    public Sprite normal;
-    public Sprite fighting;
-    public Sprite flying;
-    public Sprite poison;
-    public Sprite ground;
-    public Sprite rock;
-    public Sprite bug;
-    public Sprite ghost;
-    public Sprite steel;
-    public Sprite fire;
-    public Sprite water;
-    public Sprite grass;
-    public Sprite electric;
-    public Sprite psychic;
-    public Sprite ice;
-    public Sprite dragon;
-    public Sprite dark;
-    public Sprite fairy;
-    [Space]
-    [Header("Health bar colors")]
-    [SerializeField] Color healthyHPColor;
-    [SerializeField] Color warningHPColor;
-    [SerializeField] Color dangerHPColor;
-    [Space]
-    [Header("Moves Categories")]
-    [SerializeField] Sprite phisical;
-    [SerializeField] Sprite special;
-    [SerializeField] Sprite status;
-    [Header("Party Button Colors")]
-    [Space]
-    [SerializeField] ColorBlock cb;
-    [Header("Party Faint Colors")]
-    [SerializeField] ColorBlock fntCb;
-    [Header("Party Switch Colors")]
-    [SerializeField] ColorBlock swtchCb;
-    
-
-    public static Dictionary<ConditionID, Color> statusColors = new Dictionary<ConditionID, Color>();
-    public static Dictionary<PokemonType, Sprite> typeIcons = new Dictionary<PokemonType, Sprite>();
-    public static Dictionary<HpState, Color> hpStateColor = new Dictionary<HpState, Color>();
-    public static Dictionary<MoveCategory, Sprite> moveCategoryIcon = new Dictionary<MoveCategory, Sprite>();
-    public static ColorBlock partyMenuNormalColors;
-    public static ColorBlock partyMenuFaintColors;
-    public static ColorBlock partyMenuSwitchColors;
-
-    public Color HealthyHPColor { get => healthyHPColor; }
-    public Color WarningHPColor { get => warningHPColor; }
-    public Color DangerHPColor { get => dangerHPColor;  }
-
-    public static UIColors i;
-    
-
-    public void Awake()
+    [CreateAssetMenu(fileName = "UIColors", menuName = "")]
+    public class UIColors : ScriptableObject//make Static?
     {
-        if (i == null)
-            i = this;
-    }
+        [Header("Status colors")]
+        public Color psnColor;
+        public Color brnColor;
+        public Color parColor;
+        public Color frzColor;
+        public Color slpColor;
+        public Color fntColor;
+        [Space]
+        [Header("Type Icons")]
+        public Sprite none;
+        public Sprite normal;
+        public Sprite fighting;
+        public Sprite flying;
+        public Sprite poison;
+        public Sprite ground;
+        public Sprite rock;
+        public Sprite bug;
+        public Sprite ghost;
+        public Sprite steel;
+        public Sprite fire;
+        public Sprite water;
+        public Sprite grass;
+        public Sprite electric;
+        public Sprite psychic;
+        public Sprite ice;
+        public Sprite dragon;
+        public Sprite dark;
+        public Sprite fairy;
+        [Space]
+        [Header("Health bar colors")]
+        [SerializeField] Color healthyHPColor;
+        [SerializeField] Color warningHPColor;
+        [SerializeField] Color dangerHPColor;
+        [Space]
+        [Header("Moves Categories")]
+        [SerializeField] Sprite phisical;
+        [SerializeField] Sprite special;
+        [SerializeField] Sprite status;
+        [Header("Party Button Colors")]
+        [Space]
+        [SerializeField] ColorBlock cb;
+        [Header("Party Faint Colors")]
+        [SerializeField] ColorBlock fntCb;
+        [Header("Party Switch Colors")]
+        [SerializeField] ColorBlock swtchCb;
 
-    public void Init()
-    {
-        statusColors = new Dictionary<ConditionID, Color>()
+
+        public static Dictionary<ConditionID, Color> statusColors = new Dictionary<ConditionID, Color>();
+        public static Dictionary<PokemonType, Sprite> typeIcons = new Dictionary<PokemonType, Sprite>();
+        public static Dictionary<HpState, Color> hpStateColor = new Dictionary<HpState, Color>();
+        public static Dictionary<MoveCategory, Sprite> moveCategoryIcon = new Dictionary<MoveCategory, Sprite>();
+        public static ColorBlock partyMenuNormalColors;
+        public static ColorBlock partyMenuFaintColors;
+        public static ColorBlock partyMenuSwitchColors;
+
+        public Color HealthyHPColor { get => healthyHPColor; }
+        public Color WarningHPColor { get => warningHPColor; }
+        public Color DangerHPColor { get => dangerHPColor; }
+
+        public static UIColors i;
+
+
+        public void Awake()
+        {
+            if (i == null)
+                i = this;
+        }
+
+        public void Init()
+        {
+            statusColors = new Dictionary<ConditionID, Color>()
         {
             {ConditionID.psn, psnColor },
             {ConditionID.brn, brnColor },
@@ -86,7 +88,7 @@ public class UIColors : ScriptableObject//make Static?
             {ConditionID.fnt, fntColor }
         };
 
-        typeIcons = new Dictionary<PokemonType, Sprite>()
+            typeIcons = new Dictionary<PokemonType, Sprite>()
         {
             {PokemonType.None, null },
             {PokemonType.Normal, normal},
@@ -110,29 +112,31 @@ public class UIColors : ScriptableObject//make Static?
 
         };
 
-        hpStateColor = new Dictionary<HpState, Color>()
+            hpStateColor = new Dictionary<HpState, Color>()
         {
             { HpState.healthy, HealthyHPColor },
             { HpState.caution, WarningHPColor },
             { HpState.danger, DangerHPColor }
         };
 
-        moveCategoryIcon = new Dictionary<MoveCategory, Sprite>()
+            moveCategoryIcon = new Dictionary<MoveCategory, Sprite>()
         {
             {MoveCategory.Physical, phisical },
             {MoveCategory.Special, special },
             {MoveCategory.Status, status },
         };
 
-        partyMenuNormalColors = cb;
-        partyMenuFaintColors = fntCb;
-        partyMenuSwitchColors = swtchCb;
+            partyMenuNormalColors = cb;
+            partyMenuFaintColors = fntCb;
+            partyMenuSwitchColors = swtchCb;
 
+        }
     }
-}
 
 
-public enum HpState
-{
-    healthy, caution ,danger
+    public enum HpState
+    {
+        healthy, caution, danger
+    }
+
 }

--- a/DialogueSystem/ChoiceBox.cs
+++ b/DialogueSystem/ChoiceBox.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace pokeCopy
+{
+    public class ChoiceBox : MonoBehaviour
+    {
+
+        [SerializeField] List<Button> choicesButtons = new List<Button>();
+        List<Text> choicesTexts = new List<Text>();
+
+        int selectedIndex = -1;
+        bool selected = false;
+
+        System.Action OnSelection;
+
+        public int SelectedIndex => selectedIndex;
+
+        private void Awake()
+        {
+            if (choicesButtons.Count > 0)
+            {
+                foreach (var choice in choicesButtons)
+                {
+                    choicesTexts.Add(choice.GetComponentInChildren<Text>());
+                    choice.gameObject.SetActive(false);
+                }
+            }
+        }
+
+
+        public IEnumerator SetChoices(List<string> choicesText, List<UnityAction> actions = null)
+        {
+            gameObject.SetActive(true);
+            selected = false;
+            selectedIndex = -1;
+            for (int i = 0; i < choicesButtons.Count; i++)
+            {
+                if (i >= choicesText.Count)
+                {
+                    choicesButtons[i].gameObject.SetActive(false);
+                    continue;
+                }
+
+                choicesTexts[i].text = choicesText[i];
+                choicesButtons[i].gameObject.SetActive(true);
+
+
+
+                if (actions != null)
+                    choicesButtons[i].onClick.AddListener(actions[i]);
+
+            }
+            EventSystem.current.SetSelectedGameObject(choicesButtons[0].gameObject);
+            yield return new WaitUntil(() => selected);
+
+        }
+
+        public void SelectChoiceButton()
+        {
+            selectedIndex = choicesButtons.IndexOf(EventSystem.current.currentSelectedGameObject.GetComponent<Button>());
+
+            OnSelection?.Invoke();
+            selected = true;
+            gameObject.SetActive(false);
+        }
+
+
+
+    }
+}

--- a/DialogueSystem/ChoiceBox.cs.meta
+++ b/DialogueSystem/ChoiceBox.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e42a5a9b612ba746a91cf03c24fa9ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DialogueSystem/Dialogue.cs
+++ b/DialogueSystem/Dialogue.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace pokeCopy
+{
+
+    [System.Serializable]
+    public class Dialogue
+    {
+        [TextArea(3, 15)]
+        public string[] senteces;
+
+    }
+}
+

--- a/DialogueSystem/Dialogue.cs.meta
+++ b/DialogueSystem/Dialogue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 82ca35b979ca5964daa0f4d7a027e6a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/DialogueSystem/DialogueCacheManager.cs
+++ b/DialogueSystem/DialogueCacheManager.cs
@@ -1,0 +1,188 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.InputSystem;
+using System.Text;
+using System.Linq;
+
+namespace pokeCopy
+{
+
+    public class DialogueCacheManager : MonoBehaviour //Refactor needed
+    {
+        static DialogueCacheManager i;
+        [SerializeField] GameObject TextBox;
+        [SerializeField] Text dialogueText;
+
+        [SerializeField] ChoiceBox choiceBox;
+
+
+        public System.Action OnShowDialogue;
+        public System.Action OnCloseDialogue;
+
+        int selection = -1;
+
+        bool isShowing;
+        public static DialogueCacheManager I { get { return i; } }
+
+        public bool IsShowing { get => isShowing; }
+        public int Selection => selection; 
+
+        //singleton pattern
+        public void Awake()
+        {
+            if (i != null && i != this)
+                Destroy(this);
+            else
+                i = this;
+
+
+            //DontDestroyOnLoad(this);
+        }
+
+        // Start is called before the first frame update
+
+
+        public IEnumerator ShowText_CR(string text, bool waitInput = true, bool autoclose = true)
+        {
+
+            if (GameManager.Instance.State == GameState.freeRoam)
+                OnShowDialogue?.Invoke();
+
+            GameManager.Instance.Inputs.UI.Navigate.Disable();
+            isShowing = true;
+            TextBox.SetActive(true);
+            yield return TypeSentence_CR(text);
+
+            if (waitInput)
+            {
+                yield return new WaitUntil(() => GameManager.Instance.Inputs.UI.Submit.triggered || GameManager.Instance.Inputs.PlayerDigital.Interact.triggered);
+            }
+
+            if (!autoclose)
+                yield break;
+
+
+
+            dialogueText.text = "";
+            isShowing = false;
+            TextBox.SetActive(false);
+            GameManager.Instance.Inputs.UI.Navigate.Enable();
+
+            if (GameManager.Instance.State == GameState.Dialogue)
+                OnCloseDialogue?.Invoke();
+
+        }
+
+        //Starts dialogue. It also continues dialogue when interacting. 
+
+        public IEnumerator ShowDialogue_CR(Dialogue dialogue, List<string> choices = null)
+        {
+            if (dialogue == null || !(dialogue.senteces.Count() > 0))
+                yield break;
+            yield return new WaitForEndOfFrame();
+            OnShowDialogue?.Invoke();
+            isShowing = true;
+            TextBox.SetActive(true);
+
+            foreach (var line in dialogue.senteces)
+            {
+                //yield return TypeSentence_CR(line);
+                yield return TypeSentence_CR(line);
+                yield return new WaitUntil(() => GameManager.Instance.Inputs.UI.Submit.triggered || GameManager.Instance.Inputs.PlayerDigital.Interact.triggered);
+
+            }
+
+
+            if (choices != null && choices.Count() > 0)
+            {
+                yield return choiceBox.SetChoices(choices);
+                selection = choiceBox.SelectedIndex;
+            }
+
+            TextBox.SetActive(false);
+            isShowing = false;
+            OnCloseDialogue?.Invoke();
+        }
+
+        IEnumerator TypeSentence_CR(string sentence)
+        {
+            dialogueText.text = "";
+            foreach (char c in sentence.ToCharArray())
+            {
+                dialogueText.text += c;
+                yield return new WaitForSeconds(0.015f);
+
+            }
+
+        }
+
+        IEnumerator TypeSentenceReplacing_CR(string sentence)
+        {
+            dialogueText.text = new StringBuilder(sentence.Length).Insert(0, " ", sentence.Length).ToString();
+            int i = 0;
+            foreach (char c in sentence.ToString())
+            {
+
+                i++;
+                yield return new WaitForSeconds(0.015f);
+            }
+
+        }
+
+        /*
+        public void StartDialogue(Dialogue dialogue, System.Action onFinished = null)
+        {
+
+            if (!TextBox.activeSelf)//for contingece, in case this function starts by other means
+            {
+                OnShowDialogue?.Invoke();//using this to avoid reference GameManager
+                dialogueText.text = "";
+                sentences.Clear();
+                foreach (var s in dialogue.senteces)
+                {
+                    sentences.Enqueue(s);
+                }
+                OnFinished += onFinished;
+                TextBox.SetActive(true);
+                isFirstLine = true;
+                NextSentence();
+            }
+            //NextSentence();
+            //Old Dialogue when using only interac() to initiate next line. the isInteracting on NPCMono was determened by the end of this function
+            //Can be clean up so the iteraction state of the npc does not depend of this function anymore.
+            // return TextBox.activeSelf;
+        }
+
+        public void NextSentence()
+        {
+
+            if (sentences.Count == 0)
+            {
+                StartCoroutine(EndOfDialogue_CR());
+                return;
+            }
+            string crntSente = sentences.Dequeue();
+
+
+            StopAllCoroutines();//interupts any sentece being typed, avoiding mixed typing of different lines. Alternative to waiting until finishing one line
+            //For the case of wait til finished typing, isFirstLine can be replaced for is typing, avoiding any update on input and preventing going to the next line before the previous is completed
+            StartCoroutine(TypeSentence_CR(crntSente));
+        }
+        private IEnumerator EndOfDialogue_CR()
+        {
+            yield return null;
+            TextBox.SetActive(false);
+            dialogueText.text = "";
+            OnFinished?.Invoke();
+            OnFinished = null;
+
+            OnCloseDialogue?.Invoke();
+        }
+        */
+
+
+
+    }
+}

--- a/DialogueSystem/DialogueCacheManager.cs.meta
+++ b/DialogueSystem/DialogueCacheManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c14a7d072029f304e922075f1bb436fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Interactables/Dialogue.cs
+++ b/Interactables/Dialogue.cs
@@ -2,10 +2,15 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-[System.Serializable]
-public class Dialogue 
+namespace pokeCopy
 {
-    [TextArea (3,15)]
-    public string[] senteces;
 
+    [System.Serializable]
+    public class Dialogue
+    {
+        [TextArea(3, 15)]
+        public string[] senteces;
+
+    }
 }
+

--- a/Interactables/DialogueCacheManager.cs
+++ b/Interactables/DialogueCacheManager.cs
@@ -6,167 +6,171 @@ using UnityEngine.InputSystem;
 using System.Text;
 using System.Linq;
 
-public class DialogueCacheManager : MonoBehaviour //Refactor needed
+namespace pokeCopy
 {
-    static DialogueCacheManager i;
-    [SerializeField] GameObject TextBox;
-    [SerializeField] Text dialogueText;
 
-    public System.Action OnShowDialogue;
-    public System.Action OnCloseDialogue;
-
-
-    bool isShowing;
-    public static DialogueCacheManager I { get { return i; } }
-
-    public bool IsShowing { get => isShowing; }
-
-    //singleton pattern
-    public void Awake()
+    public class DialogueCacheManager : MonoBehaviour //Refactor needed
     {
-        if (i != null && i != this)
-            Destroy(this);
-        else
-            i = this;
+        static DialogueCacheManager i;
+        [SerializeField] GameObject TextBox;
+        [SerializeField] Text dialogueText;
+
+        public System.Action OnShowDialogue;
+        public System.Action OnCloseDialogue;
 
 
-        //DontDestroyOnLoad(this);
-    }
+        bool isShowing;
+        public static DialogueCacheManager I { get { return i; } }
 
-    // Start is called before the first frame update
+        public bool IsShowing { get => isShowing; }
 
-
-    public IEnumerator ShowText_CR(string text, bool waitInput = true, bool autoclose = true)
-    {
-
-        if (GameManager.Instance.State == GameState.freeRoam)
-            OnShowDialogue?.Invoke();
-
-        GameManager.Instance.Inputs.UI.Navigate.Disable();
-        isShowing = true;
-        TextBox.SetActive(true);
-        yield return TypeSentence_CR(text);
-
-        if (waitInput)
+        //singleton pattern
+        public void Awake()
         {
-            yield return new WaitUntil(() => GameManager.Instance.Inputs.UI.Submit.triggered || GameManager.Instance.Inputs.PlayerDigital.Interact.triggered);
+            if (i != null && i != this)
+                Destroy(this);
+            else
+                i = this;
+
+
+            //DontDestroyOnLoad(this);
         }
 
-        if (!autoclose)
-            yield break;
+        // Start is called before the first frame update
 
 
-        dialogueText.text = "";
-        isShowing = false;
-        TextBox.SetActive(false);
-        GameManager.Instance.Inputs.UI.Navigate.Enable();
-
-        if (GameManager.Instance.State == GameState.Dialogue)
-            OnCloseDialogue?.Invoke();
-
-    }
-
-    //Starts dialogue. It also continues dialogue when interacting. 
-
-    public IEnumerator ShowDialogue_CR(Dialogue dialogue)
-    {
-        if (dialogue == null || !(dialogue.senteces.Count() > 0))
-            yield break;
-        yield return new WaitForEndOfFrame();
-        OnShowDialogue?.Invoke();
-        isShowing = true;
-        TextBox.SetActive(true);
-
-        foreach (var line in dialogue.senteces)
+        public IEnumerator ShowText_CR(string text, bool waitInput = true, bool autoclose = true)
         {
-            //yield return TypeSentence_CR(line);
-            yield return TypeSentence_CR(line);
-            yield return new WaitUntil(() => GameManager.Instance.Inputs.UI.Submit.triggered || GameManager.Instance.Inputs.PlayerDigital.Interact.triggered);
 
-        }
-        TextBox.SetActive(false);
-        isShowing = false;
+            if (GameManager.Instance.State == GameState.freeRoam)
+                OnShowDialogue?.Invoke();
 
-
-        OnCloseDialogue?.Invoke();
-    }
-
-    IEnumerator TypeSentence_CR(string sentence)
-    {
-        dialogueText.text = "";
-        foreach (char c in sentence.ToCharArray())
-        {
-            dialogueText.text += c;
-            yield return new WaitForSeconds(0.015f);
-
-        }
-
-    }
-
-    IEnumerator TypeSentenceReplacing_CR(string sentence)
-    {
-        dialogueText.text = new StringBuilder(sentence.Length).Insert(0, " ", sentence.Length).ToString();
-        int i = 0;
-        foreach (char c in sentence.ToString())
-        {
-            
-            i++;
-            yield return new WaitForSeconds(0.015f);
-        }
-
-    }
-
-    /*
-    public void StartDialogue(Dialogue dialogue, System.Action onFinished = null)
-    {
-
-        if (!TextBox.activeSelf)//for contingece, in case this function starts by other means
-        {
-            OnShowDialogue?.Invoke();//using this to avoid reference GameManager
-            dialogueText.text = "";
-            sentences.Clear();
-            foreach (var s in dialogue.senteces)
-            {
-                sentences.Enqueue(s);
-            }
-            OnFinished += onFinished;
+            GameManager.Instance.Inputs.UI.Navigate.Disable();
+            isShowing = true;
             TextBox.SetActive(true);
-            isFirstLine = true;
-            NextSentence();
+            yield return TypeSentence_CR(text);
+
+            if (waitInput)
+            {
+                yield return new WaitUntil(() => GameManager.Instance.Inputs.UI.Submit.triggered || GameManager.Instance.Inputs.PlayerDigital.Interact.triggered);
+            }
+
+            if (!autoclose)
+                yield break;
+
+
+            dialogueText.text = "";
+            isShowing = false;
+            TextBox.SetActive(false);
+            GameManager.Instance.Inputs.UI.Navigate.Enable();
+
+            if (GameManager.Instance.State == GameState.Dialogue)
+                OnCloseDialogue?.Invoke();
+
         }
-        //NextSentence();
-        //Old Dialogue when using only interac() to initiate next line. the isInteracting on NPCMono was determened by the end of this function
-        //Can be clean up so the iteraction state of the npc does not depend of this function anymore.
-        // return TextBox.activeSelf;
-    }
 
-    public void NextSentence()
-    {
+        //Starts dialogue. It also continues dialogue when interacting. 
 
-        if (sentences.Count == 0)
+        public IEnumerator ShowDialogue_CR(Dialogue dialogue)
         {
-            StartCoroutine(EndOfDialogue_CR());
-            return;
+            if (dialogue == null || !(dialogue.senteces.Count() > 0))
+                yield break;
+            yield return new WaitForEndOfFrame();
+            OnShowDialogue?.Invoke();
+            isShowing = true;
+            TextBox.SetActive(true);
+
+            foreach (var line in dialogue.senteces)
+            {
+                //yield return TypeSentence_CR(line);
+                yield return TypeSentence_CR(line);
+                yield return new WaitUntil(() => GameManager.Instance.Inputs.UI.Submit.triggered || GameManager.Instance.Inputs.PlayerDigital.Interact.triggered);
+
+            }
+            TextBox.SetActive(false);
+            isShowing = false;
+
+
+            OnCloseDialogue?.Invoke();
         }
-        string crntSente = sentences.Dequeue();
+
+        IEnumerator TypeSentence_CR(string sentence)
+        {
+            dialogueText.text = "";
+            foreach (char c in sentence.ToCharArray())
+            {
+                dialogueText.text += c;
+                yield return new WaitForSeconds(0.015f);
+
+            }
+
+        }
+
+        IEnumerator TypeSentenceReplacing_CR(string sentence)
+        {
+            dialogueText.text = new StringBuilder(sentence.Length).Insert(0, " ", sentence.Length).ToString();
+            int i = 0;
+            foreach (char c in sentence.ToString())
+            {
+
+                i++;
+                yield return new WaitForSeconds(0.015f);
+            }
+
+        }
+
+        /*
+        public void StartDialogue(Dialogue dialogue, System.Action onFinished = null)
+        {
+
+            if (!TextBox.activeSelf)//for contingece, in case this function starts by other means
+            {
+                OnShowDialogue?.Invoke();//using this to avoid reference GameManager
+                dialogueText.text = "";
+                sentences.Clear();
+                foreach (var s in dialogue.senteces)
+                {
+                    sentences.Enqueue(s);
+                }
+                OnFinished += onFinished;
+                TextBox.SetActive(true);
+                isFirstLine = true;
+                NextSentence();
+            }
+            //NextSentence();
+            //Old Dialogue when using only interac() to initiate next line. the isInteracting on NPCMono was determened by the end of this function
+            //Can be clean up so the iteraction state of the npc does not depend of this function anymore.
+            // return TextBox.activeSelf;
+        }
+
+        public void NextSentence()
+        {
+
+            if (sentences.Count == 0)
+            {
+                StartCoroutine(EndOfDialogue_CR());
+                return;
+            }
+            string crntSente = sentences.Dequeue();
 
 
-        StopAllCoroutines();//interupts any sentece being typed, avoiding mixed typing of different lines. Alternative to waiting until finishing one line
-        //For the case of wait til finished typing, isFirstLine can be replaced for is typing, avoiding any update on input and preventing going to the next line before the previous is completed
-        StartCoroutine(TypeSentence_CR(crntSente));
+            StopAllCoroutines();//interupts any sentece being typed, avoiding mixed typing of different lines. Alternative to waiting until finishing one line
+            //For the case of wait til finished typing, isFirstLine can be replaced for is typing, avoiding any update on input and preventing going to the next line before the previous is completed
+            StartCoroutine(TypeSentence_CR(crntSente));
+        }
+        private IEnumerator EndOfDialogue_CR()
+        {
+            yield return null;
+            TextBox.SetActive(false);
+            dialogueText.text = "";
+            OnFinished?.Invoke();
+            OnFinished = null;
+
+            OnCloseDialogue?.Invoke();
+        }
+        */
+
+
+
     }
-    private IEnumerator EndOfDialogue_CR()
-    {
-        yield return null;
-        TextBox.SetActive(false);
-        dialogueText.text = "";
-        OnFinished?.Invoke();
-        OnFinished = null;
-
-        OnCloseDialogue?.Invoke();
-    }
-    */
-
-
-
 }

--- a/Interactables/Healer.cs
+++ b/Interactables/Healer.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace pokeCopy
+{
+    public class Healer : MonoBehaviour
+    {
+        [SerializeField] Dialogue confirmedDialogue;
+        [SerializeField] Dialogue denialDialogue;
+
+        public IEnumerator Heal(Transform player, Dialogue dialogue)
+        {
+            yield return DialogueCacheManager.I.ShowDialogue_CR(dialogue, new List<string>() { "YES", "NO" });
+
+            if (DialogueCacheManager.I.Selection == 0)
+            {
+                yield return Fader.I.FadeIn_CR(0.5f);
+                var party = player.GetComponent<PokemonParty>();
+                party.Party.ForEach(p => p.FullRecovery());
+                //maybe Update
+
+                yield return Fader.I.FadeOut_CR(.5f);
+
+                yield return DialogueCacheManager.I.ShowDialogue_CR(confirmedDialogue);
+
+            }
+            else if (DialogueCacheManager.I.Selection == 1)
+            {
+                yield return DialogueCacheManager.I.ShowDialogue_CR(denialDialogue);
+
+            }
+
+        }
+
+
+    }
+}

--- a/Interactables/Healer.cs.meta
+++ b/Interactables/Healer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 719f1a0042326254e929b4e104d571b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Interactables/IInteractable.cs
+++ b/Interactables/IInteractable.cs
@@ -2,7 +2,11 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public interface IInteractable 
+namespace pokeCopy
 {
-    public IEnumerator Interact_CR(Transform initiator = null);
+    public interface IInteractable
+    {
+        public IEnumerator Interact_CR(Transform initiator = null);
+    }
+
 }

--- a/Interactables/NPCMovement.cs
+++ b/Interactables/NPCMovement.cs
@@ -25,12 +25,14 @@ namespace pokeCopy
         CharMovement movement;
         ItemGiver giver;
         PokemonGiver pokemonGiver;
+        Healer healer;
 
         private void Awake()
         {
             movement = GetComponentInChildren<CharMovement>();
             giver = GetComponentInChildren<ItemGiver>();
             pokemonGiver = GetComponentInChildren<PokemonGiver>();
+            healer = GetComponentInChildren<Healer>();
             AdjustRoute();
 
         }
@@ -70,7 +72,6 @@ namespace pokeCopy
                 //isInteracting = true;
                 state = NPCState.dialogue;
                 movement.LookTowrds(initiator.position);
-
                 if (giver != null && giver.CanGive())
                 {
                     yield return giver.GiveItem_CR(initiator.GetComponent<PlayerMovement>());
@@ -104,6 +105,10 @@ namespace pokeCopy
                         yield return DialogueCacheManager.I.ShowDialogue_CR(activeQuest.Base.InProgressDialogue);
                     }
 
+                }
+                else if (healer)
+                {
+                    yield return healer.Heal(initiator, dialogue);
                 }
                 else
                 {
@@ -185,15 +190,15 @@ namespace pokeCopy
             {
                 activeQuest = (saveData.activeQuest != null) ? new Quest(saveData.activeQuest) : null;
 
-                questToStart = (saveData.toStartQuest != null || saveData.toStartQuest.Length > 0) ? QuestDB.GetDataByName(saveData.toStartQuest) : null;
-                questToComplete = (saveData.toFinishQuest != null || saveData.toFinishQuest.Length > 0) ? QuestDB.GetDataByName(saveData.toFinishQuest) : null;
+                questToStart = (saveData.toStartQuest != null && saveData.toStartQuest.Length > 0) ?  new Quest (QuestDB.GetDataByName(saveData.toStartQuest)).Base : null;
+                questToComplete = (saveData.toFinishQuest != null && saveData.toFinishQuest.Length > 0) ? new Quest (QuestDB.GetDataByName(saveData.toFinishQuest)).Base : null;
 
             }
 
         }
     }
 
-
+    [System.Serializable]
     public class NPCQuestSavaData
     {
         public QuestSaveData activeQuest;

--- a/Interactables/NPCMovement.cs
+++ b/Interactables/NPCMovement.cs
@@ -1,208 +1,211 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using pokeCopy;
 
-public class NPCMovement : MonoBehaviour, IInteractable, ISavable
+namespace pokeCopy
 {
-    [Header("Quests")]
-    [SerializeField] QuestBase questToStart;
-    [SerializeField] QuestBase questToComplete;
-    [Space]
-    [SerializeField] Dialogue dialogue;
-    [SerializeField] List<Vector2> routePoints;
-    [SerializeField] float patternsInterval = 2f;
-
-
-    Quest activeQuest;
-
-    NPCState state;
-    bool isInteracting;
-    float idleTimer;
-    int routeIndx;
-
-    CharMovement movement;
-    ItemGiver giver;
-    PokemonGiver pokemonGiver;
-
-    private void Awake()
+    public class NPCMovement : MonoBehaviour, IInteractable, ISavable
     {
-        movement = GetComponentInChildren<CharMovement>();
-        giver = GetComponentInChildren<ItemGiver>();
-        pokemonGiver = GetComponentInChildren<PokemonGiver>();
-        AdjustRoute();
+        [Header("Quests")]
+        [SerializeField] QuestBase questToStart;
+        [SerializeField] QuestBase questToComplete;
+        [Space]
+        [SerializeField] Dialogue dialogue;
+        [SerializeField] List<Vector2> routePoints;
+        [SerializeField] float patternsInterval = 2f;
 
-    }
 
-    public void Start()
-    {
-    }
+        Quest activeQuest;
 
-    void AdjustRoute()
-    {
-        for (int i = 0; i < routePoints.Count; i++)
+        NPCState state;
+        bool isInteracting;
+        float idleTimer;
+        int routeIndx;
+
+        CharMovement movement;
+        ItemGiver giver;
+        PokemonGiver pokemonGiver;
+
+        private void Awake()
         {
-            if (routePoints[i].x != 0 & routePoints[i].y != 0)
-            {
-                routePoints.Insert(i + 1, new Vector2(0, routePoints[i].y));
-                routePoints[i] = new Vector2(routePoints[i].x, 0);
-            }
+            movement = GetComponentInChildren<CharMovement>();
+            giver = GetComponentInChildren<ItemGiver>();
+            pokemonGiver = GetComponentInChildren<PokemonGiver>();
+            AdjustRoute();
+
         }
 
-    }
-
-    public IEnumerator Interact_CR(Transform initiator)
-    {
-        if (state == NPCState.idle && GameManager.Instance.State == GameState.freeRoam)
+        public void Start()
         {
+        }
 
-            if (questToComplete != null)
+        void AdjustRoute()
+        {
+            for (int i = 0; i < routePoints.Count; i++)
             {
-                var quest = new Quest(questToComplete);
-                yield return quest.CompleteQuest_CR(initiator);
-                questToComplete = null;
-
-                Debug.Log($"{quest.Base.name} completed.");
-
-            }
-
-            //isInteracting = true;
-            state = NPCState.dialogue;
-            movement.LookTowrds(initiator.position);
-
-            if (giver != null && giver.CanGive())
-            {
-                yield return giver.GiveItem_CR(initiator.GetComponent<PlayerMovement>());
-            }
-            else if (pokemonGiver != null && pokemonGiver.CanGive())
-            {
-                yield return pokemonGiver.GivePokemon_CR(initiator.GetComponent<PlayerMovement>());
-            }
-            else if (questToStart != null)
-            {
-                activeQuest = new Quest(questToStart);
-                yield return activeQuest.StartQuest_CR();
-                questToStart = null;
-
-                if (activeQuest.CanBeCompleted())
+                if (routePoints[i].x != 0 & routePoints[i].y != 0)
                 {
-                    yield return activeQuest.CompleteQuest_CR(initiator);
-                    activeQuest = null;
+                    routePoints.Insert(i + 1, new Vector2(0, routePoints[i].y));
+                    routePoints[i] = new Vector2(routePoints[i].x, 0);
+                }
+            }
+
+        }
+
+        public IEnumerator Interact_CR(Transform initiator)
+        {
+            if (state == NPCState.idle && GameManager.Instance.State == GameState.freeRoam)
+            {
+
+                if (questToComplete != null)
+                {
+                    var quest = new Quest(questToComplete);
+                    yield return quest.CompleteQuest_CR(initiator);
+                    questToComplete = null;
+
+                    Debug.Log($"{quest.Base.name} completed.");
+
                 }
 
-            }
-            else if (activeQuest != null)
-            {
-                if (activeQuest.CanBeCompleted())
+                //isInteracting = true;
+                state = NPCState.dialogue;
+                movement.LookTowrds(initiator.position);
+
+                if (giver != null && giver.CanGive())
                 {
-                    yield return activeQuest.CompleteQuest_CR(initiator);
-                    activeQuest = null;
+                    yield return giver.GiveItem_CR(initiator.GetComponent<PlayerMovement>());
+                }
+                else if (pokemonGiver != null && pokemonGiver.CanGive())
+                {
+                    yield return pokemonGiver.GivePokemon_CR(initiator.GetComponent<PlayerMovement>());
+                }
+                else if (questToStart != null)
+                {
+                    activeQuest = new Quest(questToStart);
+                    yield return activeQuest.StartQuest_CR();
+                    questToStart = null;
+
+                    if (activeQuest.CanBeCompleted())
+                    {
+                        yield return activeQuest.CompleteQuest_CR(initiator);
+                        activeQuest = null;
+                    }
+
+                }
+                else if (activeQuest != null)
+                {
+                    if (activeQuest.CanBeCompleted())
+                    {
+                        yield return activeQuest.CompleteQuest_CR(initiator);
+                        activeQuest = null;
+                    }
+                    else
+                    {
+                        yield return DialogueCacheManager.I.ShowDialogue_CR(activeQuest.Base.InProgressDialogue);
+                    }
+
                 }
                 else
                 {
-                    yield return DialogueCacheManager.I.ShowDialogue_CR(activeQuest.Base.InProgressDialogue);
+
+                    yield return DialogueCacheManager.I.ShowDialogue_CR(dialogue);
                 }
 
-            }
-            else
-            {
-
-                yield return DialogueCacheManager.I.ShowDialogue_CR(dialogue);
-            }
 
 
 
 
-
-            //DialogueCacheManager.I.OnCloseDialogue += ClearInteraction;
-            idleTimer = 0f;
-            state = NPCState.idle;
-
-
-        }
-        //StartCoroutine(movement.Move(new Vector2(0, 1)));
-    }
-
-    void ClearInteraction()
-    {
-        // isInteracting = false;
-        //  Debug.Log("CLEAR INTERACTION");
-        //DialogueCacheManager.I.OnCloseDialogue -= ClearInteraction;
-    }
-
-    public void Update()
-    {
-        if (isInteracting || state == NPCState.interacting)
-            return;
-
-
-        if (state == NPCState.idle)
-        {
-            idleTimer += Time.deltaTime;
-            if (idleTimer > patternsInterval)
-            {
+                //DialogueCacheManager.I.OnCloseDialogue += ClearInteraction;
                 idleTimer = 0f;
-                if (routePoints.Count > 0)
-                    StartCoroutine(WalkRoute_CR());
+                state = NPCState.idle;
+
 
             }
+            //StartCoroutine(movement.Move(new Vector2(0, 1)));
         }
 
-    }
-
-    IEnumerator WalkRoute_CR()
-    {
-        state = NPCState.walking;
-
-        var oldPos = transform.position;
-
-        yield return movement.Move(routePoints[routeIndx]);
-
-        if (transform.position != oldPos)
-            routeIndx = (routeIndx + 1) % routePoints.Count;
-
-        state = NPCState.idle;
-    }
-
-    public object CaptureState()
-    {
-        var saveData = new NPCQuestSavaData();
-        saveData.activeQuest = activeQuest?.GetSaveData();
-
-        saveData.toStartQuest = (questToStart != null) ? questToStart.name : null;
-
-        saveData.toFinishQuest = (questToComplete != null)? questToComplete.name: null;
-
-        return saveData;
-
-    }
-
-    public void RestoreState(object state)
-    {
-        var saveData = state as NPCQuestSavaData;
-        if (saveData != null)
+        void ClearInteraction()
         {
-            activeQuest = (saveData.activeQuest != null) ? new Quest(saveData.activeQuest ): null;
+            // isInteracting = false;
+            //  Debug.Log("CLEAR INTERACTION");
+            //DialogueCacheManager.I.OnCloseDialogue -= ClearInteraction;
+        }
 
-            questToStart = (saveData.toStartQuest != null || saveData.toStartQuest.Length > 0) ? QuestDB.GetDataByName(saveData.toStartQuest) : null;
-            questToComplete = (saveData.toFinishQuest != null || saveData.toFinishQuest.Length > 0) ? QuestDB.GetDataByName(saveData.toFinishQuest) : null;
+        public void Update()
+        {
+            if (isInteracting || state == NPCState.interacting)
+                return;
+
+
+            if (state == NPCState.idle)
+            {
+                idleTimer += Time.deltaTime;
+                if (idleTimer > patternsInterval)
+                {
+                    idleTimer = 0f;
+                    if (routePoints.Count > 0)
+                        StartCoroutine(WalkRoute_CR());
+
+                }
+            }
 
         }
 
+        IEnumerator WalkRoute_CR()
+        {
+            state = NPCState.walking;
+
+            var oldPos = transform.position;
+
+            yield return movement.Move(routePoints[routeIndx]);
+
+            if (transform.position != oldPos)
+                routeIndx = (routeIndx + 1) % routePoints.Count;
+
+            state = NPCState.idle;
+        }
+
+        public object CaptureState()
+        {
+            var saveData = new NPCQuestSavaData();
+            saveData.activeQuest = activeQuest?.GetSaveData();
+
+            saveData.toStartQuest = (questToStart != null) ? questToStart.name : null;
+
+            saveData.toFinishQuest = (questToComplete != null) ? questToComplete.name : null;
+
+            return saveData;
+
+        }
+
+        public void RestoreState(object state)
+        {
+            var saveData = state as NPCQuestSavaData;
+            if (saveData != null)
+            {
+                activeQuest = (saveData.activeQuest != null) ? new Quest(saveData.activeQuest) : null;
+
+                questToStart = (saveData.toStartQuest != null || saveData.toStartQuest.Length > 0) ? QuestDB.GetDataByName(saveData.toStartQuest) : null;
+                questToComplete = (saveData.toFinishQuest != null || saveData.toFinishQuest.Length > 0) ? QuestDB.GetDataByName(saveData.toFinishQuest) : null;
+
+            }
+
+        }
     }
-}
 
 
-public class NPCQuestSavaData
-{
-    public QuestSaveData activeQuest;
+    public class NPCQuestSavaData
+    {
+        public QuestSaveData activeQuest;
 
-    public string toStartQuest;
-    public string toFinishQuest;
-}
+        public string toStartQuest;
+        public string toFinishQuest;
+    }
 
 
-public enum NPCState
-{
-    idle, walking, interacting, dialogue
+    public enum NPCState
+    {
+        idle, walking, interacting, dialogue
+    }
+
 }

--- a/Managers/GameManager.cs
+++ b/Managers/GameManager.cs
@@ -1,0 +1,373 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.SceneManagement;
+using UnityEngine.EventSystems;
+using pokeCopy;
+
+public delegate void OnBattleEndHandler();
+public delegate void OnStateChangeHandler();
+
+public class GameManager : MonoBehaviour
+{
+    //static GameManager instance;
+
+    public static GameManager Instance;
+    [SerializeField] GameState state;
+    GameState prevState;
+
+    [SerializeField] PlayerMovement player;
+    [SerializeField] Camera playerCam;
+    [SerializeField] SceneData battleSceneData;
+    [SerializeField] BattleData battleData;
+    [SerializeField] GameObject battleSystem;
+    [SerializeField] MenuController menuController;
+    [SerializeField] bool isBattleAScene;
+    [SerializeField] Fader fader;
+
+    public GameState State { get => state; }
+    public PlayerMovement Player { get => player; }
+
+    public event OnStateChangeHandler OnStateChange;
+    public event OnBattleEndHandler OnBattleEnd;
+    public SceneData BattleSceneData { get => battleSceneData; set => battleSceneData = value; }
+    public BattleData BattleData { get => battleData; }
+    public PlayerInputActions Inputs { get => Player.InputActions; }
+    public bool IsBattleAScene { get => isBattleAScene; }
+
+    public EventSystem eventSystem;
+
+    public UIColors uiColors;
+
+    public SceneDetails CrrtScene { get; private set; }
+    public SceneDetails PrvScene { get; private set; }
+
+
+    public void Awake()
+    {
+        if (Instance != null && Instance != this)
+            Destroy(gameObject);
+        else
+            Instance = this;
+
+        // DontDestroyOnLoad(gameObject);
+        uiColors.Init();
+
+        menuController = GetComponent<MenuController>();
+
+        Debug.Log("GM woke");
+        //battleSceneData.ClearData();
+        PokemonDB.Init();
+        MoveDB.Init();
+        ConditionsDB.Init();
+        ItemDB.Init();
+        QuestDB.Init();
+
+        menuController.Init();
+    }
+
+
+    // Start is called before the first frame update
+    void Start()
+    {
+
+        DialogueCacheManager.I.OnShowDialogue += () =>
+        {
+            SetState(GameState.Dialogue);
+        };
+
+
+        DialogueCacheManager.I.OnCloseDialogue += () =>
+        {
+            if (state == GameState.Dialogue)
+            {
+                SetState(GameState.freeRoam);
+            }
+        };
+
+
+        EvolutionSceneUI.I.OnStartEvolution += () => SetState(GameState.Evolution);
+        EvolutionSceneUI.I.OnEndEvolution += ()
+            =>
+        {
+
+            StartCoroutine(FadeOutFromEvolution_CR());
+
+        };
+
+
+
+    }
+
+
+    public void Update()
+    {
+
+        if (state == GameState.freeRoam)
+        {
+            if (player.InputActions.PlayerDigital.OpenMenu.triggered && !player.IsMoving)
+            {
+                menuController.OpenMenu(eventSystem);
+                SetState(GameState.Menu);
+            }
+
+        }
+        else if (state == GameState.Menu)
+        {
+
+            if (player.InputActions.UI.Cancel.triggered)
+            {
+                menuController.OnBack?.Invoke();
+            }
+            if (Instance.Inputs.UI.Navigate.triggered)
+                menuController.UpdateSelection();
+
+        }
+    }
+
+    public void PauseGame(bool pause)
+    {
+        if (pause)
+        {
+            prevState = state;
+            state = GameState.Paused;
+        }
+        else
+        {
+            state = prevState;
+        }
+    }
+
+    public void StartWildBattle()
+    {
+        //pass data for
+        SetState(GameState.Battle);
+        battleData.SetPlayer(player);
+
+        battleData.IsTrainerBattle = false;
+        //eventSystem.gameObject.SetActive(false);
+
+        battleSystem.SetActive(true);
+    }
+
+    public void StartTrainerBattle(TrainerController trainer)
+    {
+        battleData.SetPlayer(player);
+
+        battleData.SetTrainer(trainer);
+        battleData.IsTrainerBattle = true;
+        //eventSystem.gameObject.SetActive(false);
+
+        SetState(GameState.Battle);
+        battleSystem.SetActive(true);
+
+    }
+
+
+    public void OnTrainerView()
+    {
+        player.InputActions.PlayerDigital.Move.Disable();
+        state = GameState.CutScene;
+
+    }
+
+    public void EndOfBattle()
+    {
+        //battleData.ClearData();
+        //StartCoroutine(FadeFromBattle());
+        //player.gameObject.SetActive(true);
+
+        StartCoroutine(FadeOutFromBattle_CR());
+
+
+    }
+
+
+    public IEnumerator FadeOutFromBattle_CR()
+    {
+        battleSystem.SetActive(false);
+        SetState(GameState.freeRoam);
+        //eventSystem.gameObject.SetActive(true);
+        yield return null;
+        StartCoroutine(fader.FadeOut_CR(.2f));
+        var party = player.GetComponent<PokemonParty>();
+        yield return party.CheckForEvolutions_CR();
+
+    }
+
+    public IEnumerator FadeOutFromEvolution_CR()
+    {
+        yield return fader.FadeIn_CR(.5f);
+        EvolutionSceneUI.I.EvolutionUI.SetActive(false);
+        SetState(GameState.freeRoam);
+        yield return fader.FadeOut_CR(.5f);
+    }
+
+    public IEnumerator FadeInToFreeRoam_CR()
+    {
+
+        yield return fader.FadeIn_CR(.5f);
+
+    }
+
+    //da
+    void StartBattleScene()
+    {
+        battleSceneData.GetPosition(player.transform.position);
+        battleSceneData.PassDirection(player.GetDirection());
+        state = GameState.Battle;
+        battleSceneData.LoadParty(player.GetComponent<PokemonParty>());
+        eventSystem.gameObject.SetActive(false);
+        SceneManager.LoadScene(1, LoadSceneMode.Additive);
+        player.gameObject.SetActive(false);
+        // SceneManager.LoadScene(1);
+
+    }
+
+    public void StartTrainerBattleScene(TrainerData info, TrainerController trainer = null)
+    {
+        battleSceneData.GetPosition(player.transform.position);
+        battleSceneData.PassDirection(player.GetDirection());
+        state = GameState.Battle;
+        //battleSceneData.GetTrainerData(trainer);
+        battleSceneData.GetTrainerData(info);
+        eventSystem.gameObject.SetActive(false);
+
+        battleSceneData.ReceiveBattleData(player.GetComponent<PokemonParty>(), info.Party);
+        //SceneManager.LoadScene(1);
+        SceneManager.LoadScene(1, LoadSceneMode.Additive);
+        player.gameObject.SetActive(false);
+    }
+
+
+
+    // Update is called once per frame
+    public void EndBattleScene()
+    {
+        state = GameState.freeRoam;
+        //playerCam.gameObject.SetActive(true);
+        battleSceneData.ClearData();
+        OnBattleEnd?.Invoke();
+        //eventSystem.gameObject.SetActive(true);
+        player.gameObject.SetActive(true);
+        SceneManager.UnloadSceneAsync(1);
+
+    }
+
+    //not implemented yet. Dependes of separation on the object level, each taking care of themself in each situation
+    public void SetState(GameState newState)
+    {
+        OnStateChange?.Invoke();// Use when invetoryUI and partyMenu are one instanc used in all situations, eg.
+        if (newState == GameState.Battle)
+        {
+            player.InputActions.PlayerDigital.Disable();
+            player.InputActions.UI.Enable();
+
+            //player.gameObject.SetActive(false);
+            playerCam.gameObject.SetActive(false);
+            //player.GetComponentInChildren<Camera>().gameObject.SetActive(false);
+        }
+
+        if (newState == GameState.freeRoam)
+        {
+            switch (state)
+            {
+                case GameState.freeRoam:
+
+                    break;
+                case GameState.Battle:
+                    battleData.ClearData();
+                    eventSystem.gameObject.SetActive(true);
+                    player.InputActions.PlayerDigital.Enable();
+                    player.InputActions.UI.Disable();
+
+                    playerCam.gameObject.SetActive(true);
+
+                    break;
+                case GameState.Evolution:
+                case GameState.Menu:
+                    player.InputActions.UI.Disable();
+                    player.InputActions.PlayerDigital.Enable();
+
+                    break;
+                case GameState.MainMenu:
+                    break;
+                case GameState.Dialogue:
+                    player.InputActions.PlayerDigital.Move.Enable();
+
+                    break;
+                case GameState.CutScene:
+                    break;
+                case GameState.Paused:
+
+                    break;
+                default:
+                    break;
+            }
+            //player.gameObject.SetActive(true);
+        }
+
+        if (newState == GameState.Dialogue)//irrelevant maybe
+        {
+            player.InputActions.PlayerDigital.Move.Disable();
+            //state = GameState.Dialogue;
+
+        }
+
+        if (newState == GameState.Menu)
+        {
+            player.InputActions.UI.Enable();
+            player.InputActions.PlayerDigital.Disable();
+        }
+
+        if (newState == GameState.Evolution)
+        {
+            player.InputActions.UI.Enable();
+            player.InputActions.PlayerDigital.Disable();
+
+        }
+
+        state = newState;
+
+    }
+
+    public void SetCurrentScene(SceneDetails scene)
+    {
+        PrvScene = CrrtScene;
+        CrrtScene = scene;
+    }
+
+
+    public void SaveButton()
+    {
+        SavingSystem.i.Save("save");
+    }
+
+    public void LoadButton()
+    {
+        SavingSystem.i.Load("save");
+    }
+
+
+
+
+    public void OnApplicationQuit()
+    {
+        Instance = null;
+    }
+}
+
+
+public enum GameState
+{
+    freeRoam,
+    Battle,
+    Menu,
+    MainMenu,
+    Dialogue,
+    CutScene,
+    Paused,
+    Evolution,
+
+}

--- a/Managers/GameManager.cs.meta
+++ b/Managers/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e8d8d37ae21f3c49b71d50b194e008d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Managers/LayersManager.cs
+++ b/Managers/LayersManager.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class LayersManager : MonoBehaviour
+{
+    [SerializeField] LayerMask unwalkable;
+    [SerializeField] LayerMask interactable;
+    [SerializeField] LayerMask grassLayer;
+    [SerializeField] LayerMask playerLayer;
+    [SerializeField] LayerMask fOVLayer;
+    [SerializeField] LayerMask portalLayer;
+
+    public static LayersManager i { get; set; }
+    public LayerMask Unwalkable { get => unwalkable;  }
+    public LayerMask Interactable { get => interactable; }
+    public LayerMask GrassLayer { get => grassLayer;  }
+    public LayerMask PlayerLayer { get => playerLayer;  }
+    public LayerMask FOVLayer { get => fOVLayer;}
+    public LayerMask PortalLayer { get => portalLayer;}
+
+    public LayerMask TriggerableLayers
+    {
+        get => portalLayer | grassLayer | fOVLayer;
+    }
+
+    public void Awake()
+    {
+        i = this;
+    }
+
+
+
+}

--- a/Managers/LayersManager.cs.meta
+++ b/Managers/LayersManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a08cd0f90c029ba43a23ac0e6212b526
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Managers/LevelManager.cs
+++ b/Managers/LevelManager.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace pokeCopy
+{
+
+    public static class LevelManager
+    {
+        /*
+        #region Singleton
+        public static LevelManager instance;
+
+        void Awake()
+        {
+            instance = this;
+            DontDestroyOnLoad(this.gameObject);
+        }
+        #endregion
+        */
+        public static int currentLevel;
+        public static float[] position = new float[3];
+
+        public static SceneData priviousScene;
+        static Scene CurrentWorldLocation;
+
+    }
+}

--- a/Managers/LevelManager.cs.meta
+++ b/Managers/LevelManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b609a187d773ade4d8f413c357f5dd24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MapDataHandler.cs
+++ b/MapDataHandler.cs
@@ -2,29 +2,33 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class MapDataHandler : MonoBehaviour
+namespace pokeCopy
 {
 
-    [SerializeField] MapData data;
-    [SerializeField] List<Pokemon> WildPokemons;
-
-
-    public Pokemon RandomEncounterWildPokemon()
+    public class MapDataHandler : MonoBehaviour
     {
-        var wildPoke = data.WildPokemons[Random.Range(0, data.WildPokemons.Count)];
-        wildPoke.Init();
-        wildPoke.RecoverFromStatus();
 
-        var wildCopy = new Pokemon(wildPoke.Base, wildPoke.Level);
-        return wildCopy;
+        [SerializeField] MapData data;
+        [SerializeField] List<Pokemon> WildPokemons;
+
+
+        public Pokemon RandomEncounterWildPokemon()
+        {
+            var wildPoke = data.WildPokemons[Random.Range(0, data.WildPokemons.Count)];
+            wildPoke.Init();
+            wildPoke.RecoverFromStatus();
+
+            var wildCopy = new Pokemon(wildPoke.Base, wildPoke.Level);
+            return wildCopy;
+        }
+
+        public void LoadWildPokemon()
+        {
+            // GameManager.Instance.BattleSceneData.LoadWilPkmn(RandomEncounterWildPokemon());
+            GameManager.Instance.BattleData.SetWildPkmn(RandomEncounterWildPokemon());
+
+        }
+
+
     }
-
-    public void LoadWildPokemon()
-    {
-       // GameManager.Instance.BattleSceneData.LoadWilPkmn(RandomEncounterWildPokemon());
-        GameManager.Instance.BattleData.SetWildPkmn(RandomEncounterWildPokemon());
-
-    }
-
-
 }

--- a/Pokemons/Condition.cs
+++ b/Pokemons/Condition.cs
@@ -3,57 +3,60 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-
-public class Condition
+namespace pokeCopy
 {
-    public ConditionID Id { get; set; }
-    
-    public string Name { get; set; }
-    public Color UIColor { get; set; }
+    public class Condition
+    {
+        public ConditionID Id { get; set; }
 
-    public string Description { get; set; }
+        public string Name { get; set; }
+        public Color UIColor { get; set; }
 
-    public string StartMessage { get; set; }
+        public string Description { get; set; }
 
-    public string FailledMassage { get; set; }
-    public AnimationClip EffectAnimation { get; set; }
+        public string StartMessage { get; set; }
 
-    public Unit Leecher { get; set; }
+        public string FailledMassage { get; set; }
+        public AnimationClip EffectAnimation { get; set; }
 
-    public PokemonType TypeResited { get; set; }
+        public Unit Leecher { get; set; }
 
-    public string ResistenceMassage { get; set; }
+        public PokemonType TypeResited { get; set; }
 
-    public Action<Pokemon, int> OnHit { get; set; }
-    public Action<Unit, Unit> OnPlantSeed { get; set; }
-    public Action<Pokemon> OnStart { get; set; }
-    public Action<Unit> SetUnit { get; set; }
+        public string ResistenceMassage { get; set; }
 
-    public Func<Pokemon, bool > OnBeforeMove { get; set; }
+        public Action<Pokemon, int> OnHit { get; set; }
+        public Action<Unit, Unit> OnPlantSeed { get; set; }
+        public Action<Pokemon> OnStart { get; set; }
+        public Action<Unit> SetUnit { get; set; }
 
-    public Func<MoveCategory, float> GetOnDamageMod { get; set; }
+        public Func<Pokemon, bool> OnBeforeMove { get; set; }
 
-    //ondamage function?
+        public Func<MoveCategory, float> GetOnDamageMod { get; set; }
 
-    public Action<Pokemon> OnAfterMove { get; set; }
+        //ondamage function?
 
-    public Func<Pokemon, int> OnAfterAllTurns { get; set; }
+        public Action<Pokemon> OnAfterMove { get; set; }
 
-    public Action<Pokemon> OnRemoveCondition { get; set; }
-}
+        public Func<Pokemon, int> OnAfterAllTurns { get; set; }
 
-[Serializable]
-public class VolCondition: Condition
-{
-    public int Timer { get; set; }
-}
+        public Action<Pokemon> OnRemoveCondition { get; set; }
+    }
+
+    [Serializable]
+    public class VolCondition : Condition
+    {
+        public int Timer { get; set; }
+    }
 
 
-public class HitEffects
-{
-    public HitEffectsID Id { get; set; }
-    public string Name { get; set; }
-    public string Message { get; set; }
-    public Action<Pokemon, int> OnHit { get; set; }
+    public class HitEffects
+    {
+        public HitEffectsID Id { get; set; }
+        public string Name { get; set; }
+        public string Message { get; set; }
+        public Action<Pokemon, int> OnHit { get; set; }
+
+    }
 
 }

--- a/Pokemons/ConditionsDB.cs
+++ b/Pokemons/ConditionsDB.cs
@@ -3,40 +3,43 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class ConditionsDB
+
+namespace pokeCopy
 {
-
-    public static void Init()
+    public class ConditionsDB
     {
-        foreach (var kvp in Conditions)
-        {
-            var conditionId = kvp.Key;
-            var condition = kvp.Value;
 
-            condition.Id = conditionId;
+        public static void Init()
+        {
+            foreach (var kvp in Conditions)
+            {
+                var conditionId = kvp.Key;
+                var condition = kvp.Value;
+
+                condition.Id = conditionId;
+            }
+
+            foreach (var kvp in VolatConditions)
+            {
+                var condId = kvp.Key;
+                var condition = kvp.Value;
+
+                condition.Id = condId;
+            }
+            foreach (var kvp in HitEffects)
+            {
+                var condId = kvp.Key;
+                var hitEffect = kvp.Value;
+
+                hitEffect.Id = condId;
+            }
+
         }
 
-        foreach (var kvp in VolatConditions)
-        {
-            var condId = kvp.Key;
-            var condition = kvp.Value;
-
-            condition.Id = condId;
-        }
-        foreach (var kvp in HitEffects)
-        {
-            var condId = kvp.Key;
-            var hitEffect = kvp.Value;
-
-            hitEffect.Id = condId;
-        }
-
-    }
-
-    //refactor
-    public static Dictionary<ConditionID, Condition> Conditions { get; set; } =
-        new Dictionary<ConditionID, Condition>()
-        {
+        //refactor
+        public static Dictionary<ConditionID, Condition> Conditions { get; set; } =
+            new Dictionary<ConditionID, Condition>()
+            {
             {
                 ConditionID.psn,
                 new Condition()
@@ -168,11 +171,11 @@ public class ConditionsDB
 
 
 
-        };
+            };
 
-    public static Dictionary<ConditionID, VolCondition> VolatConditions { get; set; } =
-    new Dictionary<ConditionID, VolCondition>()
-    {
+        public static Dictionary<ConditionID, VolCondition> VolatConditions { get; set; } =
+        new Dictionary<ConditionID, VolCondition>()
+        {
             {
                 ConditionID.confusion,
                 new VolCondition()
@@ -326,11 +329,11 @@ public class ConditionsDB
 
 
 
-    };
+        };
 
-    public static Dictionary<HitEffectsID, HitEffects> HitEffects { get; set; } =
-        new Dictionary<HitEffectsID, HitEffects>()
-        {
+        public static Dictionary<HitEffectsID, HitEffects> HitEffects { get; set; } =
+            new Dictionary<HitEffectsID, HitEffects>()
+            {
             {
                   HitEffectsID.leech_life,
                   new HitEffects()
@@ -362,34 +365,36 @@ public class ConditionsDB
 
 
 
-        };
+            };
 
 
 
-    public static float GetCatchRateMod(Condition condition)
-    {
-        if (condition == null)
+        public static float GetCatchRateMod(Condition condition)
+        {
+            if (condition == null)
+                return 1f;
+
+            if (condition.Id == ConditionID.frz || condition.Id == ConditionID.slp)
+                return 2f;
+            else if (condition.Id == ConditionID.brn || condition.Id == ConditionID.psn || condition.Id == ConditionID.par)
+                return 1.5f;
+
             return 1f;
+        }
 
-        if (condition.Id == ConditionID.frz || condition.Id == ConditionID.slp)
-            return 2f;
-        else if (condition.Id == ConditionID.brn || condition.Id == ConditionID.psn || condition.Id == ConditionID.par)
-            return 1.5f;
 
-        return 1f;
+    }
+
+    [Serializable]
+    public enum ConditionID
+    {
+        none, psn, brn, par, frz, slp, fnt, confusion, flinch, leech_seed, speedX2, foresight, leechLife,
     }
 
 
-}
+    public enum HitEffectsID
+    {
+        none, leech_life, recoilQuarter, recoilThird, recoilHalf, recoilSelf, drainHalfDmg,
+    }
 
-[Serializable]
-public enum ConditionID
-{
-    none, psn, brn, par, frz, slp, fnt, confusion, flinch, leech_seed, speedX2, foresight, leechLife,
-}
-
-
-public enum HitEffectsID
-{
-    none, leech_life, recoilQuarter, recoilThird, recoilHalf, recoilSelf, drainHalfDmg,
 }

--- a/Pokemons/Move.cs
+++ b/Pokemons/Move.cs
@@ -3,70 +3,74 @@ using System.Collections.Generic;
 using UnityEngine;
 using pokeCopy;
 
-public class Move
+namespace pokeCopy
 {
-    public MovesBase Base { get; set; }
-
-    public int Pp { get; set; }
-
-    public bool isCharged = true;
-
-    public int LastUsedTurn {get; set;}
-    public int Consecutives { get; private set; }
-    public int TurnsBfrHit { get; set; }
-
-    public Move(MovesBase pBase)
+    public class Move
     {
-        Base = pBase;
-        Pp = pBase.MaxPP;
-    }
+        public MovesBase Base { get; set; }
 
-    public Move(MoveSaveData saveData)
-    {
-        Base = MoveDB.GetDataByName(saveData.name);
-        Pp = saveData.pp;
-    }
+        public int Pp { get; set; }
 
+        public bool isCharged = true;
 
+        public int LastUsedTurn { get; set; }
+        public int Consecutives { get; private set; }
+        public int TurnsBfrHit { get; set; }
 
-    public MoveSaveData GetSaveData()
-    {
-        var saveData = new MoveSaveData()
+        public Move(MovesBase pBase)
         {
-            name = Base.name,
-            pp = this.Pp
-
-        };
-
-        return saveData;
-    }
-
-
-
-
-
-    public void consecutiveCount(int turn)
-    {
-        if(turn - LastUsedTurn > 1)
-        {
-            Consecutives = 0;
-            return;
+            Base = pBase;
+            Pp = pBase.MaxPP;
         }
 
-        Consecutives++;
+        public Move(MoveSaveData saveData)
+        {
+            Base = MoveDB.GetDataByName(saveData.name);
+            Pp = saveData.pp;
+        }
 
+
+
+        public MoveSaveData GetSaveData()
+        {
+            var saveData = new MoveSaveData()
+            {
+                name = Base.name,
+                pp = this.Pp
+
+            };
+
+            return saveData;
+        }
+
+
+
+
+
+        public void consecutiveCount(int turn)
+        {
+            if (turn - LastUsedTurn > 1)
+            {
+                Consecutives = 0;
+                return;
+            }
+
+            Consecutives++;
+
+        }
+
+
+        public void IncreasePP(int amount)
+        {
+            Pp = Mathf.Clamp(Pp + amount, 0, Base.MaxPP);
+        }
     }
 
-
-    public void IncreasePP(int amount)
+    [System.Serializable]
+    public class MoveSaveData
     {
-        Pp = Mathf.Clamp(Pp + amount, 0, Base.MaxPP);
+        public string name;
+        public int pp;
     }
-}
 
-[System.Serializable]
-public class MoveSaveData
-{
-    public string name;
-    public int pp; 
 }

--- a/Pokemons/MovesBase.cs
+++ b/Pokemons/MovesBase.cs
@@ -4,188 +4,190 @@ using UnityEngine;
 using UnityEditor;
 
 
-
-
-[CreateAssetMenu(fileName = "Move", menuName = "Pokemon/Create new move")]
-public class MovesBase : ScriptableObject, ISerializationCallbackReceiver
+namespace pokeCopy
 {
-    [SerializeField] string moveName;
-    [TextArea]
-    [SerializeField] string description;
-    
-    [SerializeField] MoveCategory category;
-    [SerializeField] PokemonType type;
-    [SerializeField] int maxPP;
-    
-    [SerializeField] float power;
-    [SerializeField] float accuracy;
 
-    [SerializeField] Target target;
-    [Space]
-    [SerializeField] bool makesContact;
-    [Space]
-    [SerializeField] MoveEffects moveEffects;
-    [SerializeField] List<SecundaryEffects> secundaries;
-
-    [Header("Move Proprities")]
-    [SerializeField] bool alwaysHits;
-    //[Range (-7,5)] 
-    [SerializeField] int priority;
-    [Space]
-    [SerializeField] bool hasChargingTurn;
-    [Space]
-    [SerializeField] HitEffectsID effectWhenHit;
-
-
-    [SerializeField] bool notAffectedByProtect;
-    [Space]
-    [Range(0,2)]
-    [SerializeField] int increasedCritRatio;
-
-    [Space]
-    [Header ("Animations")]
-    [SerializeField] AnimationClip opntAnimation;
-    [SerializeField] AnimationClip userAnimation;
-    [SerializeField] AnimationClip effectAnimation;
-
-    public void OnValidate()
+    [CreateAssetMenu(fileName = "Move", menuName = "Pokemon/Create new move")]
+    public class MovesBase : ScriptableObject, ISerializationCallbackReceiver
     {
-        Priority = priority;
+        [SerializeField] string moveName;
+        [TextArea]
+        [SerializeField] string description;
+
+        [SerializeField] MoveCategory category;
+        [SerializeField] PokemonType type;
+        [SerializeField] int maxPP;
+
+        [SerializeField] float power;
+        [SerializeField] float accuracy;
+
+        [SerializeField] Target target;
+        [Space]
+        [SerializeField] bool makesContact;
+        [Space]
+        [SerializeField] MoveEffects moveEffects;
+        [SerializeField] List<SecundaryEffects> secundaries;
+
+        [Header("Move Proprities")]
+        [SerializeField] bool alwaysHits;
+        //[Range (-7,5)] 
+        [SerializeField] int priority;
+        [Space]
+        [SerializeField] bool hasChargingTurn;
+        [Space]
+        [SerializeField] HitEffectsID effectWhenHit;
+
+
+        [SerializeField] bool notAffectedByProtect;
+        [Space]
+        [Range(0, 2)]
+        [SerializeField] int increasedCritRatio;
+
+        [Space]
+        [Header("Animations")]
+        [SerializeField] AnimationClip opntAnimation;
+        [SerializeField] AnimationClip userAnimation;
+        [SerializeField] AnimationClip effectAnimation;
+
+        public void OnValidate()
+        {
+            Priority = priority;
+        }
+
+        public void Awake()
+        {
+            moveName = name;
+        }
+
+        public void OnBeforeSerialize() { }
+
+        public void OnAfterDeserialize() => OnValidate();
+
+        public string MoveName { get => moveName; }
+        public int MaxPP { get { return maxPP; } }
+        public string Description { get => description; }
+        public PokemonType Type { get => type; }
+        public float Power { get => power; }
+        public float Accuracy { get => accuracy; }
+        public MoveCategory Category { get => category; }
+        public bool MakesContact { get => makesContact; }
+
+        public int Priority { get => priority; private set => priority = Mathf.Clamp(value, -7, 5); }
+        public bool AlwaysHits { get => alwaysHits; }
+        public MoveEffects Effects { get => moveEffects; }
+        public Target Target { get => target; }
+        public bool NotAffectedByProtect { get => notAffectedByProtect; }
+        public List<SecundaryEffects> Secundaries { get => secundaries; }
+        public int IncreasedCritRatio { get => increasedCritRatio; }
+        public HitEffectsID EffectWhenHit { get => effectWhenHit; }
+        public bool HasChargingTurn { get => hasChargingTurn; }
+        public AnimationClip UserAnimation { get => userAnimation; }
+        public AnimationClip OpntAnimation { get => opntAnimation; }
+        public AnimationClip EffectAnimation { get => effectAnimation; }
     }
 
-    public void Awake()
+    public enum MoveCategory
     {
-        moveName = name;
+        Physical,
+        Special,
+        Status
     }
 
-    public void OnBeforeSerialize() { }
-
-    public void OnAfterDeserialize() => OnValidate();
-
-    public string MoveName { get => moveName;}
-    public int MaxPP { get { return maxPP; }  }
-    public string Description { get => description; }
-    public PokemonType Type { get => type;}
-    public float Power { get => power;  }
-    public float Accuracy { get => accuracy; }
-    public MoveCategory Category { get => category;}
-    public bool MakesContact { get => makesContact; }
-
-    public int Priority { get => priority; private set => priority = Mathf.Clamp(value, -7, 5); }
-    public bool AlwaysHits { get => alwaysHits;  }
-    public MoveEffects Effects { get => moveEffects; }
-    public Target Target { get => target;  }
-    public bool NotAffectedByProtect { get => notAffectedByProtect; }
-    public List<SecundaryEffects> Secundaries { get => secundaries;}
-    public int IncreasedCritRatio { get => increasedCritRatio; }
-    public HitEffectsID EffectWhenHit { get => effectWhenHit;  }
-    public bool HasChargingTurn { get => hasChargingTurn; }
-    public AnimationClip UserAnimation { get => userAnimation; }
-    public AnimationClip OpntAnimation { get => opntAnimation;  }
-    public AnimationClip EffectAnimation { get => effectAnimation;  }
-}
-
-public enum MoveCategory
-{
-    Physical,
-    Special,
-    Status
-}
-
-public enum Target
-{
-    Foe,//One Enemy
-    Self,
-    NotIMPL_Ally,//One next ally
-    NotIMPL_Adj,//one ally and two enemies
-    NotIMPL_Others,//Everyone but self
-    NotIMPL_Opponents,//All foes
-    NotIMPL_TeamAndSelf,//Allies and Self
-    NotIMPL_Mates,//Only allies
-    NotIMPL_Everyone,
-}
-
-
-[System.Serializable]
-public class MoveEffects
-{
-    [SerializeField] ConditionID condition;
-    [SerializeField] List<StatModsStage> statMods;
-
-
-
-    public List<StatModsStage> StatMods { get { return statMods; } }
-
-    public ConditionID Condition { get => condition; }
-
-}
-
-
-[System.Serializable]
-public class SecundaryEffects : MoveEffects
-{
-    [Range (0,101)]
-    [SerializeField] int statusChance;
-    [SerializeField] Target effectTarget;
-    [SerializeField] int antecipation;//remove and use a move propety called hasChargin turn
-
-
-
-    public int StatusChance { get => statusChance; }
-    public Target Target { get => effectTarget; }
-    public int Antecipation { get => antecipation;}
-
-}
-
-
-[System.Serializable]
-public class StatModsStage
-{
-    public Stat stat;
-    [Range(-6,+6)]
-    public int stage;
-}
-
-public enum Effect
-{
-    AtkUp,
-    AtkDwn,
-}
-
-public static class ProtectiveSuccessTest
-{
-    const int outOf = 65536;
-
-    const int rate = 65535;
-
-    const int cap = 65535 / 4;
-
-    static readonly float[] chanceTable = new float[] {rate/outOf, 32767 /outOf, 16383 /outOf, 8191 /outOf};
-
-    public static bool HasSuccess(int consecUse)
+    public enum Target
     {
-        int turnRate =Mathf.FloorToInt( rate / Mathf.Pow(2, consecUse));
-        return (Mathf.Max( turnRate, rate/8  )) >= Random.Range(1, outOf);
+        Foe,//One Enemy
+        Self,
+        NotIMPL_Ally,//One next ally
+        NotIMPL_Adj,//one ally and two enemies
+        NotIMPL_Others,//Everyone but self
+        NotIMPL_Opponents,//All foes
+        NotIMPL_TeamAndSelf,//Allies and Self
+        NotIMPL_Mates,//Only allies
+        NotIMPL_Everyone,
     }
 
-    public static bool SuccessFromTable(int turn)
+
+    [System.Serializable]
+    public class MoveEffects
     {
-        return Random.value >= chanceTable[Mathf.Clamp(turn -1, 0, 3)];
+        [SerializeField] ConditionID condition;
+        [SerializeField] List<StatModsStage> statMods;
+
+
+
+        public List<StatModsStage> StatMods { get { return statMods; } }
+
+        public ConditionID Condition { get => condition; }
+
     }
 
-}
 
-public static class RecoilTable//CONSIDER USING A DICTIONARY INSTEAD OF ARRAY
-{
-
-    static float[] recoilMod = new float[] { 0.25f, 0.33f, 0.5f };
-
-    public static float GetRecoil(RecoilDmg mod)
+    [System.Serializable]
+    public class SecundaryEffects : MoveEffects
     {
-        return recoilMod[Mathf.Max((int)mod, 2)];
+        [Range(0, 101)]
+        [SerializeField] int statusChance;
+        [SerializeField] Target effectTarget;
+        [SerializeField] int antecipation;//remove and use a move propety called hasChargin turn
+
+
+
+        public int StatusChance { get => statusChance; }
+        public Target Target { get => effectTarget; }
+        public int Antecipation { get => antecipation; }
+
     }
-}
-public enum RecoilDmg
-{
-    halfOfDmg,  thirdOfDmg, quaterOfDmg,  quaterOfMaxHP
+
+
+    [System.Serializable]
+    public class StatModsStage
+    {
+        public Stat stat;
+        [Range(-6, +6)]
+        public int stage;
+    }
+
+    public enum Effect
+    {
+        AtkUp,
+        AtkDwn,
+    }
+
+    public static class ProtectiveSuccessTest
+    {
+        const int outOf = 65536;
+
+        const int rate = 65535;
+
+        const int cap = 65535 / 4;
+
+        static readonly float[] chanceTable = new float[] { rate / outOf, 32767 / outOf, 16383 / outOf, 8191 / outOf };
+
+        public static bool HasSuccess(int consecUse)
+        {
+            int turnRate = Mathf.FloorToInt(rate / Mathf.Pow(2, consecUse));
+            return (Mathf.Max(turnRate, rate / 8)) >= Random.Range(1, outOf);
+        }
+
+        public static bool SuccessFromTable(int turn)
+        {
+            return Random.value >= chanceTable[Mathf.Clamp(turn - 1, 0, 3)];
+        }
+
+    }
+
+    public static class RecoilTable//CONSIDER USING A DICTIONARY INSTEAD OF ARRAY
+    {
+
+        static float[] recoilMod = new float[] { 0.25f, 0.33f, 0.5f };
+
+        public static float GetRecoil(RecoilDmg mod)
+        {
+            return recoilMod[Mathf.Max((int)mod, 2)];
+        }
+    }
+    public enum RecoilDmg
+    {
+        halfOfDmg, thirdOfDmg, quaterOfDmg, quaterOfMaxHP
+    }
 }

--- a/Pokemons/Pokemon.cs
+++ b/Pokemons/Pokemon.cs
@@ -6,222 +6,225 @@ using UnityEditor;
 using UnityEngine.Events;
 using pokeCopy;
 
-[System.Serializable]
-public class Pokemon : ISerializationCallbackReceiver
+namespace pokeCopy
 {
 
-    [SerializeField] PokemonBase _base;
-    [SerializeField] int level;
-    
-    [SerializeField] private string nickName;
-    Gender gender;
-
-    public PokemonBase Base { get => _base; }
-    public string Species { get; private set; }
-    public string NickName
+    [System.Serializable]
+    public class Pokemon : ISerializationCallbackReceiver
     {
-        get => (nickName.Length > 0 && !nickName.StartsWith(" ")) ? nickName : Species;
-        set => nickName = value ?? "";
-    }
 
+        [SerializeField] PokemonBase _base;
+        [SerializeField] int level;
 
-    public int Level { get => level; private set => level = Mathf.Clamp(value, 1, 100); }
+        [SerializeField] private string nickName;
+        Gender gender;
 
-    public int Exp { get; set; }
-
-
-    bool hasLeveledUp;
-
-    [SerializeField] [ReadOnly] int hp;
-    public int HP { get { return hp; } private set { hp = Mathf.Max(value, 0); } }
-
-    public List<Move> MoveSet { get; set; }
-
-    public Dictionary<Stat, int> Stats { get; private set; }
-
-    public Dictionary<Stat, float> StatMods { get; private set; }
-    public Queue<string> StatusChangeQuote { get; private set; }
-
-    public float spDmgMod { get; set; }
-    public float phDmgMod { get; set; }
-
-
-    public Condition Status { get; private set; }
-
-    public int StatusTimer { get; set; }
-
-    public List<VolCondition> Volat { get; private set; }
-    public List<int> VolatTimers { get; private set; }
-
-
-    public delegate void HpChanges();
-    public delegate void StatusChanged();
-
-    public HpChanges OnHPChange;
-    public StatusChanged OnStatusChanged;
-
-    [SerializeField] bool hasFixedNature;
-    [SerializeField] NatureID nature;
-
-    public void OnValidate() => Level = level;
-
-
-    public Pokemon(PokemonBase pBase, int pLevel, string nick = null)
-    {
-        _base = pBase;
-        Level = pLevel;
-        NickName = nick;
-        Init();
-    }
-
-
-    public Pokemon(PokemonSaveData saveData)
-    {
-        _base = PokemonDB.GetDataByName(saveData.species);
-        Species = Base.name.Substring(Base.name.IndexOfAny(new char[] { '_', ' ' }) + 1);
-        nature = saveData.nature;
-        gender = saveData.gender;
-        level = saveData.level;
-        Exp = saveData.xp;
-        NickName = saveData.nickName;
-        CalculateStats();
-        hp = saveData.hp;
-
-        if (saveData.status != null)
-            Status = ConditionsDB.Conditions[saveData.status.Value];
-        else
-            Status = null;
-
-        MoveSet = saveData.moves.Select(m => new Move(m)).ToList();
-
-        StatusChangeQuote = new Queue<string>();
-        Volat = new List<VolCondition>();
-        VolatTimers = new List<int>();
-        RemoveAllVolat();
-
-
-        SetStatsMods();
-
-    }
-
-    public PokemonSaveData GetSaveData()
-    {
-        var saveData = new PokemonSaveData()
+        public PokemonBase Base { get => _base; }
+        public string Species { get; private set; }
+        public string NickName
         {
-            species = Base.name,
-            nickName = this.nickName,
-            gender = this.gender,
-            hp = HP,
-            level = Level,
-            xp = Exp,
-            status = Status?.Id,
-            nature = this.nature,
-            moves = MoveSet.Select(m => m.GetSaveData()).ToList()
-
-        };
-
-
-        return saveData;
-    }
-
-    public void Init(bool randomNature = true)
-    {
-
-        //Species = _Base.name.Remove(0, _Base.name.IndexOfAny(new char[] { '_', ' ' })+1);
-        Species = Base.name.Substring(Base.name.IndexOfAny(new char[] { '_', ' ' }) + 1);
-        if (randomNature && !hasFixedNature)
-            nature = (NatureID)Random.Range(0, 24);
-        //nature = (NatureID)(Mathf.Abs( GetHashCode()) % 24);
-
-        gender = GenderGenerator.GetPokemondGender(_base);
-
-        StatusChangeQuote = new Queue<string>();
-
-        Status = null;
-        Volat = new List<VolCondition>();
-        VolatTimers = new List<int>();
-        RemoveAllVolat();
-
-
-        MoveSet = new List<Move>();
-        foreach (var move in Base.Leanrnables)
-        {
-            if (MoveSet.Count >= PokemonBase.MAX_MOVES_COUNT || move.BaseMove == null)
-                break;
-
-            if (move.Level <= Level)
-                MoveSet.Add(new Move(move.BaseMove));
-
+            get => (nickName.Length > 0 && !nickName.StartsWith(" ")) ? nickName : Species;
+            set => nickName = value ?? "";
         }
 
 
-        Exp = Base.GetExpForLevel(level);
+        public int Level { get => level; private set => level = Mathf.Clamp(value, 1, 100); }
+
+        public int Exp { get; set; }
 
 
-        CalculateStats();
-        HP = MaxHP;
-        SetStatsMods();
+        bool hasLeveledUp;
 
-        spDmgMod = 1f;
-        phDmgMod = 1f;
-    }
+        [SerializeField][ReadOnly] int hp;
+        public int HP { get { return hp; } private set { hp = Mathf.Max(value, 0); } }
 
-    public bool HasLeveledUp()
-    {
-        hasLeveledUp = false;
-        if (Exp < Base.GetExpForLevel(level + 1) || level >= 100)
+        public List<Move> MoveSet { get; set; }
+
+        public Dictionary<Stat, int> Stats { get; private set; }
+
+        public Dictionary<Stat, float> StatMods { get; private set; }
+        public Queue<string> StatusChangeQuote { get; private set; }
+
+        public float spDmgMod { get; set; }
+        public float phDmgMod { get; set; }
+
+
+        public Condition Status { get; private set; }
+
+        public int StatusTimer { get; set; }
+
+        public List<VolCondition> Volat { get; private set; }
+        public List<int> VolatTimers { get; private set; }
+
+
+        public delegate void HpChanges();
+        public delegate void StatusChanged();
+
+        public HpChanges OnHPChange;
+        public StatusChanged OnStatusChanged;
+
+        [SerializeField] bool hasFixedNature;
+        [SerializeField] NatureID nature;
+
+        public void OnValidate() => Level = level;
+
+
+        public Pokemon(PokemonBase pBase, int pLevel, string nick = null)
+        {
+            _base = pBase;
+            Level = pLevel;
+            NickName = nick;
+            Init();
+        }
+
+
+        public Pokemon(PokemonSaveData saveData)
+        {
+            _base = PokemonDB.GetDataByName(saveData.species);
+            Species = Base.name.Substring(Base.name.IndexOfAny(new char[] { '_', ' ' }) + 1);
+            nature = saveData.nature;
+            gender = saveData.gender;
+            level = saveData.level;
+            Exp = saveData.xp;
+            NickName = saveData.nickName;
+            CalculateStats();
+            hp = saveData.hp;
+
+            if (saveData.status != null)
+                Status = ConditionsDB.Conditions[saveData.status.Value];
+            else
+                Status = null;
+
+            MoveSet = saveData.moves.Select(m => new Move(m)).ToList();
+
+            StatusChangeQuote = new Queue<string>();
+            Volat = new List<VolCondition>();
+            VolatTimers = new List<int>();
+            RemoveAllVolat();
+
+
+            SetStatsMods();
+
+        }
+
+        public PokemonSaveData GetSaveData()
+        {
+            var saveData = new PokemonSaveData()
+            {
+                species = Base.name,
+                nickName = this.nickName,
+                gender = this.gender,
+                hp = HP,
+                level = Level,
+                xp = Exp,
+                status = Status?.Id,
+                nature = this.nature,
+                moves = MoveSet.Select(m => m.GetSaveData()).ToList()
+
+            };
+
+
+            return saveData;
+        }
+
+        public void Init(bool randomNature = true)
+        {
+
+            //Species = _Base.name.Remove(0, _Base.name.IndexOfAny(new char[] { '_', ' ' })+1);
+            Species = Base.name.Substring(Base.name.IndexOfAny(new char[] { '_', ' ' }) + 1);
+            if (randomNature && !hasFixedNature)
+                nature = (NatureID)Random.Range(0, 24);
+            //nature = (NatureID)(Mathf.Abs( GetHashCode()) % 24);
+
+            gender = GenderGenerator.GetPokemondGender(_base);
+
+            StatusChangeQuote = new Queue<string>();
+
+            Status = null;
+            Volat = new List<VolCondition>();
+            VolatTimers = new List<int>();
+            RemoveAllVolat();
+
+
+            MoveSet = new List<Move>();
+            foreach (var move in Base.Leanrnables)
+            {
+                if (MoveSet.Count >= PokemonBase.MAX_MOVES_COUNT || move.BaseMove == null)
+                    break;
+
+                if (move.Level <= Level)
+                    MoveSet.Add(new Move(move.BaseMove));
+
+            }
+
+
+            Exp = Base.GetExpForLevel(level);
+
+
+            CalculateStats();
+            HP = MaxHP;
+            SetStatsMods();
+
+            spDmgMod = 1f;
+            phDmgMod = 1f;
+        }
+
+        public bool HasLeveledUp()
+        {
+            hasLeveledUp = false;
+            if (Exp < Base.GetExpForLevel(level + 1) || level >= 100)
+                return hasLeveledUp;
+
+            ++level;
+            hasLeveledUp = true;
+            RecaulculateStatsAndHP();
             return hasLeveledUp;
 
-        ++level;
-        hasLeveledUp = true;
-        RecaulculateStatsAndHP();
-        return hasLeveledUp;
+        }
 
-    }
+        public ByLevelMoves GetLearnableMoveAtLevel()
+        {
+            return Base.Leanrnables.Where(x => x.Level == level).FirstOrDefault();
+        }
 
-    public ByLevelMoves GetLearnableMoveAtLevel()
-    {
-        return Base.Leanrnables.Where(x => x.Level == level).FirstOrDefault();
-    }
-
-    public void LearnMove(MovesBase moveToLearn)
-    {
-        if (MoveSet.Count >= PokemonBase.MAX_MOVES_COUNT)
-            return;
-        MoveSet.Add(new Move(moveToLearn));
-    }
+        public void LearnMove(MovesBase moveToLearn)
+        {
+            if (MoveSet.Count >= PokemonBase.MAX_MOVES_COUNT)
+                return;
+            MoveSet.Add(new Move(moveToLearn));
+        }
 
 
 
 
-    void CalculateStats()
-    {
-        var natureMods = PokeNature.GetNatureModfier(nature);
+        void CalculateStats()
+        {
+            var natureMods = PokeNature.GetNatureModfier(nature);
 
-        //Add nature modfier
-        Stats = new Dictionary<Stat, int>();
-        Stats.Add(Stat.Attack, Mathf.FloorToInt((((Base.Attack * Level) / 100f) + 5) * natureMods[(int)Stat.Attack]));
-        Stats.Add(Stat.Defense, Mathf.FloorToInt((((Base.Defense * Level) / 100f) + 5) * natureMods[(int)Stat.Defense]));
-        Stats.Add(Stat.SpecialAtk, Mathf.FloorToInt((((Base.SpAttack * Level) / 100f) + 5) * natureMods[(int)Stat.SpecialAtk]));
-        Stats.Add(Stat.SpecialDef, Mathf.FloorToInt((((Base.SpDefense * Level) / 100f) + 5) * natureMods[(int)Stat.SpecialDef]));
-        Stats.Add(Stat.Speed, Mathf.FloorToInt((((Base.Speed * Level) / 100f) + 5) * natureMods[(int)Stat.Speed]));
+            //Add nature modfier
+            Stats = new Dictionary<Stat, int>();
+            Stats.Add(Stat.Attack, Mathf.FloorToInt((((Base.Attack * Level) / 100f) + 5) * natureMods[(int)Stat.Attack]));
+            Stats.Add(Stat.Defense, Mathf.FloorToInt((((Base.Defense * Level) / 100f) + 5) * natureMods[(int)Stat.Defense]));
+            Stats.Add(Stat.SpecialAtk, Mathf.FloorToInt((((Base.SpAttack * Level) / 100f) + 5) * natureMods[(int)Stat.SpecialAtk]));
+            Stats.Add(Stat.SpecialDef, Mathf.FloorToInt((((Base.SpDefense * Level) / 100f) + 5) * natureMods[(int)Stat.SpecialDef]));
+            Stats.Add(Stat.Speed, Mathf.FloorToInt((((Base.Speed * Level) / 100f) + 5) * natureMods[(int)Stat.Speed]));
 
-        //var oldMaxHP = MaxHP;
-        MaxHP = Mathf.FloorToInt(((Base.MaxHP * Level) / 100f) + Level + 10);
-        //TakeHeal(MaxHP - oldMaxHP);
-    }
+            //var oldMaxHP = MaxHP;
+            MaxHP = Mathf.FloorToInt(((Base.MaxHP * Level) / 100f) + Level + 10);
+            //TakeHeal(MaxHP - oldMaxHP);
+        }
 
-    void RecaulculateStatsAndHP()
-    {
-        var oldHp = MaxHP;
-        CalculateStats();
-        TakeHeal(MaxHP - oldHp);
-    }
+        void RecaulculateStatsAndHP()
+        {
+            var oldHp = MaxHP;
+            CalculateStats();
+            TakeHeal(MaxHP - oldHp);
+        }
 
 
-    void SetStatsMods()
-    {
-        StatMods = new Dictionary<Stat, float>()
+        void SetStatsMods()
+        {
+            StatMods = new Dictionary<Stat, float>()
         {
             {Stat.Attack, 1f },
             {Stat.Defense, 1f },
@@ -232,347 +235,349 @@ public class Pokemon : ISerializationCallbackReceiver
             {Stat.Evasion, 1f },
             {Stat.Critical, 1f },
         };
-    }
+        }
 
 
-    public bool HasMove(MovesBase moveCheck)
-    {
-        return MoveSet.Count(m => m.Base == moveCheck) > 0;
-    }
-
-    public EvolutionCriteria CanEvolveInto()
-    {
-        
-        return (hasLeveledUp)? Base.Evolutions.FirstOrDefault(e=> e.RequiredLevel <= Level) : null;
-    }
-
-    public void Evolve(EvolutionCriteria evolution)
-    {
-        if (!Base.Evolutions.Contains(evolution))
-            return;
-          
-        _base = evolution.Evolution;
-
-        RecaulculateStatsAndHP();
-        Species = Base.name.Substring(Base.name.IndexOfAny(new char[] { '_', ' ' }) + 1);
-        hasLeveledUp = false;
-        /*
-        var oldHp = MaxHP;
-        CalculateStats();
-        TakeHeal(MaxHP - oldHp);
-        */
-    }
-
-    public int GetBaseStat(Stat stat)
-    {
-
-        if (stat == Stat.Speed && Status?.Id == ConditionID.par)
-            return Mathf.FloorToInt(Stats[stat] * 0.75f);
-
-        return Mathf.FloorToInt(Stats[stat] * StatMods[stat]);
-
-        /* Using boosts on pokemon intead of battleUnit
-        int stage = StatsBoost[stat];
-
-        if (stage > 0)
-            return Mathf.FloorToInt(statVal * BoostTable.GetBoostValue(stage));
-
-        return Mathf.FloorToInt(statVal * BoostTable.GetBoostValue(-stage));
-        */
-    }
-
-    public int Attack
-    {
-        get { return Stats[Stat.Attack]; }
-    }
-    public int Defense
-    {
-        get { return Stats[Stat.Defense]; }
-    }
-    public int SpAttack
-    {
-        get { return Stats[Stat.SpecialAtk]; }
-    }
-    public int SpDefense
-    {
-        get { return Stats[Stat.SpecialDef]; }
-    }
-    public int Speed
-    {
-        get { return Stats[Stat.Speed]; }
-    }
-    public int MaxHP { get; private set; }
-    public Gender Gender  => gender;
-
-    //public Nature Nature { get => nature; set => nature = value; }
-
-    public bool TakeMoveDamage(Move move, Pokemon attacker)
-    {
-
-        float eff = Effectiveness.GetAllEffectivenesses(move.Base.Type, Base.Type1, Base.Type2);
-        float aff = Effectiveness.GetAllAffinities(move.Base.Type, attacker.Base.Type1, attacker.Base.Type2);
-        float modifiers = Random.Range(.85f, 1f) * eff * aff;
-
-        float atk = (move.Base.Category == MoveCategory.Special) ? attacker.GetBaseStat(Stat.SpecialAtk) : attacker.GetBaseStat(Stat.Attack);
-        float def = (move.Base.Category == MoveCategory.Special) ? SpDefense : Defense;
-
-
-        float l = (2 * Level + 10) / 250;
-        float bdmg = l * move.Base.Power * (atk / def) + 2;
-        int damage = Mathf.FloorToInt(bdmg * modifiers);
-
-
-        HP -= damage;
-        OnHPChange?.Invoke();
-
-        if (HP <= 0)
+        public bool HasMove(MovesBase moveCheck)
         {
-            HP = 0;
+            return MoveSet.Count(m => m.Base == moveCheck) > 0;
+        }
+
+        public EvolutionCriteria CanEvolveInto()
+        {
+
+            return (hasLeveledUp) ? Base.Evolutions.FirstOrDefault(e => e.RequiredLevel <= Level) : null;
+        }
+
+        public void Evolve(EvolutionCriteria evolution)
+        {
+            if (!Base.Evolutions.Contains(evolution))
+                return;
+
+            _base = evolution.Evolution;
+
+            RecaulculateStatsAndHP();
+            Species = Base.name.Substring(Base.name.IndexOfAny(new char[] { '_', ' ' }) + 1);
+            hasLeveledUp = false;
+            /*
+            var oldHp = MaxHP;
+            CalculateStats();
+            TakeHeal(MaxHP - oldHp);
+            */
+        }
+
+        public int GetBaseStat(Stat stat)
+        {
+
+            if (stat == Stat.Speed && Status?.Id == ConditionID.par)
+                return Mathf.FloorToInt(Stats[stat] * 0.75f);
+
+            return Mathf.FloorToInt(Stats[stat] * StatMods[stat]);
+
+            /* Using boosts on pokemon intead of battleUnit
+            int stage = StatsBoost[stat];
+
+            if (stage > 0)
+                return Mathf.FloorToInt(statVal * BoostTable.GetBoostValue(stage));
+
+            return Mathf.FloorToInt(statVal * BoostTable.GetBoostValue(-stage));
+            */
+        }
+
+        public int Attack
+        {
+            get { return Stats[Stat.Attack]; }
+        }
+        public int Defense
+        {
+            get { return Stats[Stat.Defense]; }
+        }
+        public int SpAttack
+        {
+            get { return Stats[Stat.SpecialAtk]; }
+        }
+        public int SpDefense
+        {
+            get { return Stats[Stat.SpecialDef]; }
+        }
+        public int Speed
+        {
+            get { return Stats[Stat.Speed]; }
+        }
+        public int MaxHP { get; private set; }
+        public Gender Gender => gender;
+
+        //public Nature Nature { get => nature; set => nature = value; }
+
+        public bool TakeMoveDamage(Move move, Pokemon attacker)
+        {
+
+            float eff = Effectiveness.GetAllEffectivenesses(move.Base.Type, Base.Type1, Base.Type2);
+            float aff = Effectiveness.GetAllAffinities(move.Base.Type, attacker.Base.Type1, attacker.Base.Type2);
+            float modifiers = Random.Range(.85f, 1f) * eff * aff;
+
+            float atk = (move.Base.Category == MoveCategory.Special) ? attacker.GetBaseStat(Stat.SpecialAtk) : attacker.GetBaseStat(Stat.Attack);
+            float def = (move.Base.Category == MoveCategory.Special) ? SpDefense : Defense;
+
+
+            float l = (2 * Level + 10) / 250;
+            float bdmg = l * move.Base.Power * (atk / def) + 2;
+            int damage = Mathf.FloorToInt(bdmg * modifiers);
+
+
+            HP -= damage;
+            OnHPChange?.Invoke();
+
+            if (HP <= 0)
+            {
+                HP = 0;
+                return true;
+            }
+            return false;
+        }
+
+        public bool TakeConfusionDmg()
+        {
+
+            float burn = (Status?.Id == ConditionID.brn) ? .5f : 1f;
+            float l = (2 * Level + 10) / 250f;
+
+            float bdmg = l * 40 * (GetBaseStat(Stat.Attack) / GetBaseStat(Stat.Defense)) + 2;
+            int damage = Mathf.FloorToInt(bdmg * Random.Range(0.85f, 1f) * burn);
+
+            TakeDamage(damage);
+
             return true;
         }
-        return false;
-    }
 
-    public bool TakeConfusionDmg()
-    {
-
-        float burn = (Status?.Id == ConditionID.brn) ? .5f : 1f;
-        float l = (2 * Level + 10) / 250f;
-
-        float bdmg = l * 40 * (GetBaseStat(Stat.Attack) / GetBaseStat(Stat.Defense)) + 2;
-        int damage = Mathf.FloorToInt(bdmg * Random.Range(0.85f, 1f) * burn);
-
-        TakeDamage(damage);
-
-        return true;
-    }
-
-    public bool TakeDamage(int damage)
-    {
-        HP = Mathf.Max(HP - damage, 0);
-
-        OnHPChange?.Invoke();
-
-        if (HP <= 0)
-            return true;
-
-        return false;
-    }
-
-    public void TakeHeal(int healAmount)
-    {
-        HP = Mathf.Min((HP + healAmount), MaxHP);
-
-        OnHPChange?.Invoke();
-    }
-
-    public void RestorePPByMove(int ppAmount, Move move)
-    {
-        if (MoveSet.Contains(move))
+        public bool TakeDamage(int damage)
         {
-            move.Pp += ppAmount;
-        }
-    }
+            HP = Mathf.Max(HP - damage, 0);
 
-    public void RestorePPAllMoves(int ppAmount)
-    {
-        foreach(var m in MoveSet)
-        {
-            m.Pp += ppAmount;
-        }
-    }
+            OnHPChange?.Invoke();
 
-    public void ApplyCondition(ConditionID id)
-    {
-        if (ConditionsDB.Conditions.ContainsKey(id))
-            ReceiveStatus(id);
+            if (HP <= 0)
+                return true;
 
-        //if (ConditionsDB.VolatConditions.ContainsKey(id))
-        //ReceiveVolatile(id)
-    }
-
-    public void ReceiveStatus(ConditionID status)
-    {
-        if (Status != null && status != ConditionID.fnt)
-        {
-            StatusChangeQuote.Enqueue($"{NickName} is not affected.");
-
-            return;
+            return false;
         }
 
-
-
-        PokemonType resistence = ConditionsDB.Conditions[status].TypeResited;
-        if (resistence != PokemonType.None && (resistence == Base.Type1 || resistence == Base.Type2))
+        public void TakeHeal(int healAmount)
         {
-            StatusChangeQuote.Enqueue($"{NickName} {ConditionsDB.Conditions[status].ResistenceMassage}");
-            return;
+            HP = Mathf.Min((HP + healAmount), MaxHP);
+
+            OnHPChange?.Invoke();
         }
 
-        Status = ConditionsDB.Conditions[status];
-        Status?.OnStart?.Invoke(this);
-        StatusChangeQuote.Enqueue($"{NickName} {Status.StartMessage}");
-        if (status != ConditionID.fnt)
+        public void RestorePPByMove(int ppAmount, Move move)
+        {
+            if (MoveSet.Contains(move))
+            {
+                move.Pp += ppAmount;
+            }
+        }
+
+        public void RestorePPAllMoves(int ppAmount)
+        {
+            foreach (var m in MoveSet)
+            {
+                m.Pp += ppAmount;
+            }
+        }
+
+        public void ApplyCondition(ConditionID id)
+        {
+            if (ConditionsDB.Conditions.ContainsKey(id))
+                ReceiveStatus(id);
+
+            //if (ConditionsDB.VolatConditions.ContainsKey(id))
+            //ReceiveVolatile(id)
+        }
+
+        public void ReceiveStatus(ConditionID status)
+        {
+            if (Status != null && status != ConditionID.fnt)
+            {
+                StatusChangeQuote.Enqueue($"{NickName} is not affected.");
+
+                return;
+            }
+
+
+
+            PokemonType resistence = ConditionsDB.Conditions[status].TypeResited;
+            if (resistence != PokemonType.None && (resistence == Base.Type1 || resistence == Base.Type2))
+            {
+                StatusChangeQuote.Enqueue($"{NickName} {ConditionsDB.Conditions[status].ResistenceMassage}");
+                return;
+            }
+
+            Status = ConditionsDB.Conditions[status];
+            Status?.OnStart?.Invoke(this);
+            StatusChangeQuote.Enqueue($"{NickName} {Status.StartMessage}");
+            if (status != ConditionID.fnt)
+                OnStatusChanged?.Invoke();
+
+        }
+
+        public void RecoverFromStatus()
+        {
+            Status?.OnRemoveCondition?.Invoke(this);
+            Status = null;
             OnStatusChanged?.Invoke();
 
-    }
-
-    public void RecoverFromStatus()
-    {
-        Status?.OnRemoveCondition?.Invoke(this);
-        Status = null;
-        OnStatusChanged?.Invoke();
-
-    }
-
-    public void ReceiveVolatile(ConditionID volCond, Unit self = null, Unit leecher = null)
-    {
-
-        if (Volat.Contains(ConditionsDB.VolatConditions[volCond]))
-        {
-            if (ConditionsDB.VolatConditions[volCond].FailledMassage != null)
-                StatusChangeQuote.Enqueue(ConditionsDB.VolatConditions[volCond].FailledMassage);
-            return;
         }
 
-        var resistence = ConditionsDB.VolatConditions[volCond].TypeResited;
-        if (resistence != PokemonType.None && (resistence == Base.Type1 || resistence == Base.Type2))
+        public void ReceiveVolatile(ConditionID volCond, Unit self = null, Unit leecher = null)
         {
-            StatusChangeQuote.Enqueue($"{NickName} {ConditionsDB.VolatConditions[volCond].ResistenceMassage}");
-            return;
-        }
 
-        Volat.Add(ConditionsDB.VolatConditions[volCond]);
-        VolatTimers.Add(Volat[Volat.Count - 1].Timer);
-
-        Volat[Volat.Count - 1]?.OnPlantSeed?.Invoke(self, leecher);
-        Volat[Volat.Count - 1]?.OnStart?.Invoke(this);
-        if (Volat[Volat.Count - 1].StartMessage != "")
-            StatusChangeQuote.Enqueue($"{NickName} {Volat[Volat.Count - 1].StartMessage}");
-
-    }
-
-    public void RecoverFromVolat(ConditionID volCond)
-    {
-        VolatTimers.RemoveAt(Volat.IndexOf(ConditionsDB.VolatConditions[volCond]));
-        Volat.Remove(ConditionsDB.VolatConditions[volCond]);
-    }
-
-    public void RemoveAllVolat()
-    {
-        VolatTimers.Clear();
-        Volat.Clear();
-    }
-
-    public bool BeforeTurnEffects()
-    {
-        bool canPeformMove = true;
-
-        if (Volat.Contains(ConditionsDB.VolatConditions[ConditionID.flinch]))//change this
-        {
-            if (!Volat[Volat.IndexOf(ConditionsDB.VolatConditions[ConditionID.flinch])].OnBeforeMove(this))
+            if (Volat.Contains(ConditionsDB.VolatConditions[volCond]))
             {
-                canPeformMove = false;
+                if (ConditionsDB.VolatConditions[volCond].FailledMassage != null)
+                    StatusChangeQuote.Enqueue(ConditionsDB.VolatConditions[volCond].FailledMassage);
+                return;
+            }
 
+            var resistence = ConditionsDB.VolatConditions[volCond].TypeResited;
+            if (resistence != PokemonType.None && (resistence == Base.Type1 || resistence == Base.Type2))
+            {
+                StatusChangeQuote.Enqueue($"{NickName} {ConditionsDB.VolatConditions[volCond].ResistenceMassage}");
+                return;
+            }
+
+            Volat.Add(ConditionsDB.VolatConditions[volCond]);
+            VolatTimers.Add(Volat[Volat.Count - 1].Timer);
+
+            Volat[Volat.Count - 1]?.OnPlantSeed?.Invoke(self, leecher);
+            Volat[Volat.Count - 1]?.OnStart?.Invoke(this);
+            if (Volat[Volat.Count - 1].StartMessage != "")
+                StatusChangeQuote.Enqueue($"{NickName} {Volat[Volat.Count - 1].StartMessage}");
+
+        }
+
+        public void RecoverFromVolat(ConditionID volCond)
+        {
+            VolatTimers.RemoveAt(Volat.IndexOf(ConditionsDB.VolatConditions[volCond]));
+            Volat.Remove(ConditionsDB.VolatConditions[volCond]);
+        }
+
+        public void RemoveAllVolat()
+        {
+            VolatTimers.Clear();
+            Volat.Clear();
+        }
+
+        public bool BeforeTurnEffects()
+        {
+            bool canPeformMove = true;
+
+            if (Volat.Contains(ConditionsDB.VolatConditions[ConditionID.flinch]))//change this
+            {
+                if (!Volat[Volat.IndexOf(ConditionsDB.VolatConditions[ConditionID.flinch])].OnBeforeMove(this))
+                {
+                    canPeformMove = false;
+
+                }
+            }
+
+            if (Volat != null && Volat.Count > 0)
+            {
+                for (int i = 0; i < Volat.Count; i++)
+                {
+                    var prvsCount = Volat.Count;
+                    if (Volat[i].OnBeforeMove != null)
+                        if (!Volat[i].OnBeforeMove(this) && canPeformMove)
+                        {
+                            canPeformMove = false;
+                        }
+
+                    if (prvsCount > Volat.Count)
+                        i--;
+
+                }
+            }
+
+            if (Status?.OnBeforeMove != null)
+            {
+                if (!Status.OnBeforeMove(this) && canPeformMove)
+                    canPeformMove = false;
+            }
+
+            return canPeformMove;
+        }
+
+        public void AfterTurnEffects()
+        {
+            Status?.OnAfterMove?.Invoke(this);
+
+            if (Volat != null && Volat.Count > 0)
+            {
+                for (int i = 0; i < Volat.Count; i++)
+                {
+                    var prvsCount = Volat.Count;
+
+                    Volat[i]?.OnAfterMove?.Invoke(this);
+                    if (prvsCount > Volat.Count)
+                        i--;
+
+                }
             }
         }
 
-        if (Volat != null && Volat.Count > 0)
-        {
-            for (int i = 0; i < Volat.Count; i++)
-            {
-                var prvsCount = Volat.Count;
-                if (Volat[i].OnBeforeMove != null)
-                    if (!Volat[i].OnBeforeMove(this) && canPeformMove)
-                    {
-                        canPeformMove = false;
-                    }
 
-                if (prvsCount > Volat.Count)
-                    i--;
+        public int? OnEndOfRoundEffects()
+        {
+            int? residual = null;
+            if (Volat != null && Volat.Count > 0)
+            {
+                for (int i = 0; i < Volat.Count; i++)
+                {
+                    var prvsCount = Volat.Count;
+
+                    residual = Volat[i]?.OnAfterAllTurns?.Invoke(this);
+                    if (prvsCount > Volat.Count)
+                        i--;
+
+                }
 
             }
+            return residual;
         }
 
-        if (Status?.OnBeforeMove != null)
+        public Move GetRandomMove()
         {
-            if (!Status.OnBeforeMove(this) && canPeformMove)
-                canPeformMove = false;
+            var moveWithPP = MoveSet.Where(x => x.Pp > 0).ToList();
+
+            int m = Random.Range(0, MoveSet.Count);
+            return moveWithPP[m];
         }
 
-        return canPeformMove;
+        public void EndOfBattle() { }
+
+        public void OnBeforeSerialize() => this.OnValidate();
+
+        public void OnAfterDeserialize() { }
+
+
+
+
     }
 
-    public void AfterTurnEffects()
+    [System.Serializable]
+    public class PokemonSaveData
     {
-        Status?.OnAfterMove?.Invoke(this);
-
-        if (Volat != null && Volat.Count > 0)
-        {
-            for (int i = 0; i < Volat.Count; i++)
-            {
-                var prvsCount = Volat.Count;
-
-                Volat[i]?.OnAfterMove?.Invoke(this);
-                if (prvsCount > Volat.Count)
-                    i--;
-
-            }
-        }
+        public string species;
+        public string nickName;
+        public Gender gender;
+        public int hp;
+        public int level;
+        public int xp;
+        public ConditionID? status;
+        public NatureID nature;
+        public List<MoveSaveData> moves;
     }
-
-
-    public int? OnEndOfRoundEffects()
-    {
-        int? residual = null;
-        if (Volat != null && Volat.Count > 0)
-        {
-            for (int i = 0; i < Volat.Count; i++)
-            {
-                var prvsCount = Volat.Count;
-
-                residual = Volat[i]?.OnAfterAllTurns?.Invoke(this);
-                if (prvsCount > Volat.Count)
-                    i--;
-
-            }
-
-        }
-        return residual;
-    }
-
-    public Move GetRandomMove()
-    {
-        var moveWithPP = MoveSet.Where(x => x.Pp > 0).ToList();
-
-        int m = Random.Range(0, MoveSet.Count);
-        return moveWithPP[m];
-    }
-
-    public void EndOfBattle() { }
-
-    public void OnBeforeSerialize() => this.OnValidate();
-
-    public void OnAfterDeserialize() { }
-
 
 
 
 }
-
-[System.Serializable]
-public class PokemonSaveData
-{
-    public string species;
-    public string nickName;
-    public Gender gender;
-    public int hp;
-    public int level;
-    public int xp;
-    public ConditionID? status;
-    public NatureID nature;
-    public List<MoveSaveData> moves;
-}
-
-
 

--- a/Pokemons/Pokemon.cs
+++ b/Pokemons/Pokemon.cs
@@ -33,7 +33,7 @@ namespace pokeCopy
         public int Exp { get; set; }
 
 
-        bool hasLeveledUp;
+        bool didLeveledUp;
 
         [SerializeField][ReadOnly] int hp;
         public int HP { get { return hp; } private set { hp = Mathf.Max(value, 0); } }
@@ -171,14 +171,13 @@ namespace pokeCopy
 
         public bool HasLeveledUp()
         {
-            hasLeveledUp = false;
             if (Exp < Base.GetExpForLevel(level + 1) || level >= 100)
-                return hasLeveledUp;
+                return false;
 
             ++level;
-            hasLeveledUp = true;
+            didLeveledUp = true;
             RecaulculateStatsAndHP();
-            return hasLeveledUp;
+            return true;
 
         }
 
@@ -246,7 +245,7 @@ namespace pokeCopy
         public EvolutionCriteria CanEvolveInto()
         {
 
-            return (hasLeveledUp) ? Base.Evolutions.FirstOrDefault(e => e.RequiredLevel <= Level) : null;
+            return (didLeveledUp)? Base.Evolutions.FirstOrDefault(e => e.RequiredLevel <= Level): null ;
         }
 
         public void Evolve(EvolutionCriteria evolution)
@@ -258,7 +257,7 @@ namespace pokeCopy
 
             RecaulculateStatsAndHP();
             Species = Base.name.Substring(Base.name.IndexOfAny(new char[] { '_', ' ' }) + 1);
-            hasLeveledUp = false;
+            didLeveledUp = false;
             /*
             var oldHp = MaxHP;
             CalculateStats();
@@ -306,6 +305,8 @@ namespace pokeCopy
         }
         public int MaxHP { get; private set; }
         public Gender Gender => gender;
+
+        public bool DoesLevelUp { get => didLeveledUp; set => didLeveledUp = value; }
 
         //public Nature Nature { get => nature; set => nature = value; }
 
@@ -367,6 +368,14 @@ namespace pokeCopy
             HP = Mathf.Min((HP + healAmount), MaxHP);
 
             OnHPChange?.Invoke();
+        }
+
+        public void FullRecovery()
+        {
+            TakeHeal(MaxHP);
+            Status = null;
+            OnStatusChanged?.Invoke();
+            RemoveAllVolat();
         }
 
         public void RestorePPByMove(int ppAmount, Move move)

--- a/Pokemons/PokemonBase.cs
+++ b/Pokemons/PokemonBase.cs
@@ -2,152 +2,158 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-[CreateAssetMenu(fileName = "Pokemon", menuName = "Pokemon/Create new pokemon")]
-public class PokemonBase : ScriptableObject
+
+
+
+namespace pokeCopy
 {
 
-    [TextArea]
-    [SerializeField] string description;
-    [SerializeField] byte catchRate = 255;
-    [SerializeField] int xpYield;
-    [SerializeField] Species_Gender_Threshold genderDistribution;
-    [SerializeField] LevelingRate growth;
-    [Header("Sprites")]
-    [SerializeField] Sprite front;
-    [SerializeField] Sprite back;
-    [SerializeField] Sprite chibi;
-    [Header("Types")]
-    [SerializeField] PokemonType type1;
-    [SerializeField] PokemonType type2;
-    [Header("Base Stats")]
-    [SerializeField] int maxHP;
-    [SerializeField] int attack;
-    [SerializeField] int defense;
-    [SerializeField] int spAttack;
-    [SerializeField] int spDefense;
-    [SerializeField] int speed;
-    [Space]
-    [SerializeField] List<ByLevelMoves> leanrnables;
-    [SerializeField] List<MovesBase> TM_n_HM;
-    [SerializeField] List<EvolutionCriteria> evolutions;
-
-
-
-    public string Description { get => description; }
-
-    public Sprite Front { get => front; }
-    public Sprite Back { get => back; }
-    public Sprite Chibi => chibi;
-    public PokemonType Type1 { get => type1; }
-    public PokemonType Type2 { get => type2; }
-
-
-
-    public int MaxHP { get => maxHP; }
-    public int Attack { get { return attack; } }
-    public int Defense { get => defense; }
-    public int SpAttack { get => spAttack; }
-    public int SpDefense { get => spDefense; }
-    public int Speed { get => speed; }
-    public List<ByLevelMoves> Leanrnables { get => leanrnables; }
-
-    public static int MAX_MOVES_COUNT => 4;
-
-    public byte CatchRate => catchRate;
-
-    public int ExpYield => xpYield;
-
-    public LevelingRate Growth => growth;
-
-    public List<MovesBase> TM_n_HM_Leanrnables => TM_n_HM;
-
-    public Species_Gender_Threshold GenderThreshold => genderDistribution;
-
-    public List<EvolutionCriteria> Evolutions => evolutions;
-
-    public int GetExpForLevel(int level)
+    [CreateAssetMenu(fileName = "Pokemon", menuName = "Pokemon/Create new pokemon")]
+    public class PokemonBase : ScriptableObject
     {
-        return ExpTable.GetXPFromLevel(level, growth);
-    }
-}
 
-[System.Serializable]
-public class ByLevelMoves : ISerializationCallbackReceiver
-{
-    [SerializeField] MovesBase baseMove;
-    [SerializeField] int level;
+        [TextArea]
+        [SerializeField] string description;
+        [SerializeField] byte catchRate = 255;
+        [SerializeField] int xpYield;
+        [SerializeField] Species_Gender_Threshold genderDistribution;
+        [SerializeField] LevelingRate growth;
+        [Header("Sprites")]
+        [SerializeField] Sprite front;
+        [SerializeField] Sprite back;
+        [SerializeField] Sprite chibi;
+        [Header("Types")]
+        [SerializeField] PokemonType type1;
+        [SerializeField] PokemonType type2;
+        [Header("Base Stats")]
+        [SerializeField] int maxHP;
+        [SerializeField] int attack;
+        [SerializeField] int defense;
+        [SerializeField] int spAttack;
+        [SerializeField] int spDefense;
+        [SerializeField] int speed;
+        [Space]
+        [SerializeField] List<ByLevelMoves> leanrnables;
+        [SerializeField] List<MovesBase> TM_n_HM;
+        [SerializeField] List<EvolutionCriteria> evolutions;
 
-    public MovesBase BaseMove { get => baseMove; }
-    public int Level { get => level; private set => level = Mathf.Clamp(value, 1, 100); }
 
-    public void OnAfterDeserialize() { }
 
-    public void OnBeforeSerialize() => OnValidate();
+        public string Description { get => description; }
 
-    public void OnValidate()
-    {
-        Level = level;
+        public Sprite Front { get => front; }
+        public Sprite Back { get => back; }
+        public Sprite Chibi => chibi;
+        public PokemonType Type1 { get => type1; }
+        public PokemonType Type2 { get => type2; }
+
+
+
+        public int MaxHP { get => maxHP; }
+        public int Attack { get { return attack; } }
+        public int Defense { get => defense; }
+        public int SpAttack { get => spAttack; }
+        public int SpDefense { get => spDefense; }
+        public int Speed { get => speed; }
+        public List<ByLevelMoves> Leanrnables { get => leanrnables; }
+
+        public static int MAX_MOVES_COUNT => 4;
+
+        public byte CatchRate => catchRate;
+
+        public int ExpYield => xpYield;
+
+        public LevelingRate Growth => growth;
+
+        public List<MovesBase> TM_n_HM_Leanrnables => TM_n_HM;
+
+        public Species_Gender_Threshold GenderThreshold => genderDistribution;
+
+        public List<EvolutionCriteria> Evolutions => evolutions;
+
+        public int GetExpForLevel(int level)
+        {
+            return ExpTable.GetXPFromLevel(level, growth);
+        }
     }
 
-
-}
-
-public enum PokemonType
-{
-    None,
-    Normal,
-    Fighting,
-    Flying,
-    Poison,
-    Ground,
-    Rock,
-    Bug,
-    Ghost,
-    Steel,
-    Fire,
-    Water,
-    Grass,
-    Electric,
-    Psychic,
-    Ice,
-    Dragon,
-    Dark,
-    Fairy,
-}
-
-
-public enum Stat
-{
-    Attack,
-    Defense,
-    SpecialAtk,
-    SpecialDef,
-    Speed,
-    Evasion,
-    Accuracy,
-    Critical,
-}
-
-
-
-public struct DamageDetails
-{
-    public bool Fainted { get; set; }
-    public float Critical { get; set; }
-    public float Effectiveness { get; set; }
-
-    public int Damage { get; set; }
-
-    public int OnUserSideEffect { get; set; }
-
-
-}
-
-
-public class Effectiveness
-{
-    static readonly float[][] chart =
+    [System.Serializable]
+    public class ByLevelMoves : ISerializationCallbackReceiver
     {
+        [SerializeField] MovesBase baseMove;
+        [SerializeField] int level;
+
+        public MovesBase BaseMove { get => baseMove; }
+        public int Level { get => level; private set => level = Mathf.Clamp(value, 1, 100); }
+
+        public void OnAfterDeserialize() { }
+
+        public void OnBeforeSerialize() => OnValidate();
+
+        public void OnValidate()
+        {
+            Level = level;
+        }
+
+
+    }
+
+    public enum PokemonType
+    {
+        None,
+        Normal,
+        Fighting,
+        Flying,
+        Poison,
+        Ground,
+        Rock,
+        Bug,
+        Ghost,
+        Steel,
+        Fire,
+        Water,
+        Grass,
+        Electric,
+        Psychic,
+        Ice,
+        Dragon,
+        Dark,
+        Fairy,
+    }
+
+
+    public enum Stat
+    {
+        Attack,
+        Defense,
+        SpecialAtk,
+        SpecialDef,
+        Speed,
+        Evasion,
+        Accuracy,
+        Critical,
+    }
+
+
+
+    public struct DamageDetails
+    {
+        public bool Fainted { get; set; }
+        public float Critical { get; set; }
+        public float Effectiveness { get; set; }
+
+        public int Damage { get; set; }
+
+        public int OnUserSideEffect { get; set; }
+
+
+    }
+
+
+    public class Effectiveness
+    {
+        static readonly float[][] chart =
+        {
         // row = atk, col =def     NOR  FGT  FLG  POS  GRD  RCK  BUG  GHT  STL  FIR  WTR  GRS  ELC  PSY  ICE  DRG  DRK  FAR
 		/* NOR */   new float[] {  1f,  1f,  1f,  1f,  1f, .5f,  1f,  0f, .5f,  1f,  1f,  1f,  1f,  1f,  1f,  1f,  1f,  1f }, 
 		/* FGT */   new float[] {  2f,  1f, .5f, .5f,  1f,  2f, .5f,  0f,  2f,  1f,  1f,  1f,  1f, .5f,  2f,  1f,  2f, .5f }, 
@@ -169,71 +175,71 @@ public class Effectiveness
 		/* FAR */   new float[] {  1f,  2f,  1f, .5f,  1f,  1f,  1f,  1f, .5f, .5f,  1f,  1f,  1f,  1f,  1f,  2f,  2f,  1f },
 
     };
-    public static float GetEffectivenes(PokemonType attackType, PokemonType defenseType)
-    {
-        if (attackType == PokemonType.None || defenseType == PokemonType.None)
-            return 1;
+        public static float GetEffectivenes(PokemonType attackType, PokemonType defenseType)
+        {
+            if (attackType == PokemonType.None || defenseType == PokemonType.None)
+                return 1;
 
-        //int row = (int)attackType - 1;
-        //int col = (int)defenseType - 1;
+            //int row = (int)attackType - 1;
+            //int col = (int)defenseType - 1;
 
-        return chart[((int)attackType) - 1][(int)defenseType - 1];
+            return chart[((int)attackType) - 1][(int)defenseType - 1];
+        }
+
+        public static float GetAllEffectivenesses(PokemonType attackType, PokemonType defense1, PokemonType defense2)
+        {
+            float t1 = GetEffectivenes(attackType, defense1);
+            float t2 = GetEffectivenes(attackType, defense2);
+
+            return (defense1 != defense2) ? t1 * t2 : t1;
+        }
+
+        public static float GetAffinityMod(PokemonType move, PokemonType pokemonType)
+        {
+            return (move == pokemonType) ? 1.5f : 1f;
+        }
+
+        public static float GetAllAffinities(PokemonType move, PokemonType type1, PokemonType type2)
+        {
+            float t1 = GetAffinityMod(move, type1);
+            float t2 = GetAffinityMod(move, type2);
+
+            return Mathf.Max(t1, t2);
+        }
     }
 
-    public static float GetAllEffectivenesses(PokemonType attackType, PokemonType defense1, PokemonType defense2)
-    {
-        float t1 = GetEffectivenes(attackType, defense1);
-        float t2 = GetEffectivenes(attackType, defense2);
 
-        return (defense1 != defense2) ? t1 * t2 : t1;
+
+    public static class BoostTable
+    {
+        static readonly float[] values = new float[] { 1f, 1.5f, 2f, 2.5f, 3f, 3.5f, 4f };
+
+        static readonly float[] hitValues = new float[] { .33f, .36f, .43f, .5f, .6f, .75f, 1f, 1.33f, 1.66f, 2f, 2.5f, 2.66f, 3f };
+
+        static readonly float[] critBonus = new float[] { 0.0625f, 0.125f, 0.25f, 0.333f, 0.5f, 1f };
+
+        public static float GetBoostValue(int stage)
+        {
+            return values[stage];
+        }
+
+        public static float GetPrecision(int stage)
+        {
+            return hitValues[stage + 6];
+        }
+
+        public static float GetCritBoost(int stage)
+        {
+            return critBonus[Mathf.Clamp(stage, 0, 4)];
+        }
+
     }
 
-    public static float GetAffinityMod(PokemonType move, PokemonType pokemonType)
+    public static class ExpTable
     {
-        return (move == pokemonType) ? 1.5f : 1f;
-    }
 
-    public static float GetAllAffinities(PokemonType move, PokemonType type1, PokemonType type2)
-    {
-        float t1 = GetAffinityMod(move, type1);
-        float t2 = GetAffinityMod(move, type2);
-
-        return Mathf.Max(t1, t2);
-    }
-}
-
-
-
-public static class BoostTable
-{
-    static readonly float[] values = new float[] { 1f, 1.5f, 2f, 2.5f, 3f, 3.5f, 4f };
-
-    static readonly float[] hitValues = new float[] { .33f, .36f, .43f, .5f, .6f, .75f, 1f, 1.33f, 1.66f, 2f, 2.5f, 2.66f, 3f };
-
-    static readonly float[] critBonus = new float[] { 0.0625f, 0.125f, 0.25f, 0.333f, 0.5f, 1f };
-
-    public static float GetBoostValue(int stage)
-    {
-        return values[stage];
-    }
-
-    public static float GetPrecision(int stage)
-    {
-        return hitValues[stage + 6];
-    }
-
-    public static float GetCritBoost(int stage)
-    {
-        return critBonus[Mathf.Clamp(stage, 0, 4)];
-    }
-
-}
-
-public static class ExpTable
-{
-
-    static readonly int[][] expTable =
-    {
+        static readonly int[][] expTable =
+        {
         /* 1 */ new int[] { 0, 0, 0, 0, 0, 0 },
         /* 2 */ new int[] { 15, 6, 8, 9, 10, 4 },
         /* 3 */ new int[] { 52, 21, 27, 57, 33, 13 },
@@ -336,40 +342,40 @@ public static class ExpTable
         /* 100 */new int[] { 600000, 800000, 1000000, 1059860, 1250000, 1640000 },
     };
 
-    public static int GetSize()
-    {
-        return expTable.Length;
+        public static int GetSize()
+        {
+            return expTable.Length;
+        }
+        public static int GetNumGrowthTypes()
+        {
+            int i = Random.Range(0, 99);
+            Debug.Log(i);
+            return expTable[i].Length;
+        }
+
+        public static int GetXPFromLevel(int level, LevelingRate growth)
+        {
+            if (level > 100)
+                return -1;
+
+            return expTable[level - 1][(int)growth];
+        }
     }
-    public static int GetNumGrowthTypes()
+
+    [System.Serializable]
+    public class EvolutionCriteria
     {
-        int i = Random.Range(0, 99);
-        Debug.Log(i);
-        return expTable[i].Length;
+        [SerializeField] PokemonBase evolution;
+        [SerializeField] int requiredLevel;
+
+        public PokemonBase Evolution => evolution;
+        public int RequiredLevel => requiredLevel;
     }
 
-    public static int GetXPFromLevel(int level, LevelingRate growth)
+    public static class PokeNature
     {
-        if (level > 100)
-            return -1;
-
-        return expTable[level - 1][(int)growth];
-    }
-}
-
-[System.Serializable]
-public class EvolutionCriteria
-{
-    [SerializeField] PokemonBase evolution;
-    [SerializeField] int requiredLevel;
-
-    public PokemonBase Evolution => evolution;
-    public int RequiredLevel => requiredLevel;
-}
-
-public static class PokeNature
-{
-    static readonly float[][] natureMods =
-    {
+        static readonly float[][] natureMods =
+        {
         /* Hardy    */    new float[] {1f,  1f, 1f, 1f, 1f },
         /* Lonely   */    new float[] {1.1f, .9f, 1f, 1f, 1f },
         /* Adamant  */    new float[] {1.1f, 1f, .9f, 1f, 1f },
@@ -398,46 +404,48 @@ public static class PokeNature
 
     };
 
-    public static float[] GetNatureModfier(NatureID nature)
-    {
-        return natureMods[(int)nature];
+        public static float[] GetNatureModfier(NatureID nature)
+        {
+            return natureMods[(int)nature];
+        }
+
     }
 
-}
-
-public enum LevelingRate
-{
-    erratic, fast, mid_fast, mid_slow, slow, fluctuant,
-}
-
-
-public static class GenderGenerator
-{
-    public static Gender GetPokemondGender(PokemonBase species)
+    public enum LevelingRate
     {
-        if (species.GenderThreshold == Species_Gender_Threshold.NoGender)
-            return Gender.Genderless;
+        erratic, fast, mid_fast, mid_slow, slow, fluctuant,
+    }
 
-        if ((byte)Random.Range(1, 252) >= (byte)species.GenderThreshold)
-            return Gender.Male;
 
-        return Gender.Female;
+    public static class GenderGenerator
+    {
+        public static Gender GetPokemondGender(PokemonBase species)
+        {
+            if (species.GenderThreshold == Species_Gender_Threshold.NoGender)
+                return Gender.Genderless;
+
+            if ((byte)Random.Range(1, 252) >= (byte)species.GenderThreshold)
+                return Gender.Male;
+
+            return Gender.Female;
+        }
+    }
+
+    public enum Species_Gender_Threshold : byte
+    {
+        F1_M1 = 127,
+        M = 0,
+        M7_F1 = 31,
+        M3_F1 = 63,
+        F3_M1 = 191,
+        F7_M1 = 225,
+        F = 254,
+        NoGender
+    }
+
+    public enum Gender
+    {
+        Male, Female, Genderless
     }
 }
 
-public enum Species_Gender_Threshold : byte
-{
-    F1_M1 = 127,
-    M = 0,
-    M7_F1 = 31,
-    M3_F1 = 63,
-    F3_M1 = 191,
-    F7_M1 = 225,
-    F = 254,
-    NoGender
-}
-
-public enum Gender
-{
-    Male, Female, Genderless
-}

--- a/Pokemons/PokemonParty.cs
+++ b/Pokemons/PokemonParty.cs
@@ -4,91 +4,95 @@ using System.Linq;
 using UnityEngine;
 using pokeCopy;
 
-public class PokemonParty : MonoBehaviour
+namespace pokeCopy
 {
-
-    [SerializeField] List<Pokemon> party = new List<Pokemon>();
-    string trainerName;
-
-    public static int MAX_PARTY_SIZE = 6;
-
-    public List<Pokemon> Party { get => party; set => party = value; }
-    public string TrainerName { get => trainerName; set => trainerName = value; }
-
-    public void Start()
+    public class PokemonParty : MonoBehaviour
     {
-        foreach (var p in Party) 
-            p.Init();
 
-        trainerName = GetComponent<INamable>().Name;
-    }
+        [SerializeField] List<Pokemon> party = new List<Pokemon>();
+        string trainerName;
 
-    public void AddToParty(Pokemon p)
-    {
-        if (Party.Count >= 6)
+        public static int MAX_PARTY_SIZE = 6;
+
+        public List<Pokemon> Party { get => party; set => party = value; }
+        public string TrainerName { get => trainerName; set => trainerName = value; }
+
+        public void Start()
         {
-            //TO DO: Add to PC after implementing it
+            foreach (var p in Party)
+                p.Init();
+
+            trainerName = GetComponent<INamable>().Name;
         }
-            
 
-        Party.Add(p);
-
-    }
-    public void RemoveFromParty(int index)
-    {
-        if (Party.Count <= 1)
-            return;
-
-        Party.RemoveAt(index);
-    }
-
-    public void SwapPosition(int pokemon1, int pokemon2)
-    {
-        var mB = Mathf.Max(pokemon1, pokemon2);
-        var mS = Mathf.Min(pokemon1, pokemon2);
-
-        var p1 = party[mS];
-        party.Insert(mB,p1);
-        var p2 = party[mB + 1];
-        party.Insert(mS, p2);
-        party.RemoveAt(mS + 1);
-        party.RemoveAt(mB+ 1);
-
-
-    }
-
-    public Pokemon Retrive(int index)
-    {
-        return (index >= Party.Count) ? null : Party[index];
-    }
-
-
-    public Pokemon GetHealthy()
-    {
-        return Party.Where(x => x.HP > 0).FirstOrDefault();
-    }
-
-
-    public IEnumerator CheckForEvolutions_CR()
-    {
-
-        foreach (var pokemon in party)
+        public void AddToParty(Pokemon p)
         {
-            var evolution = pokemon.CanEvolveInto();
-            if (evolution != null)
+            if (Party.Count >= 6)
             {
-                yield return EvolutionSceneUI.I.StartEvolution_CR(pokemon, evolution);
+                //TO DO: Add to PC after implementing it
             }
 
+
+            Party.Add(p);
+
+        }
+        public void RemoveFromParty(int index)
+        {
+            if (Party.Count <= 1)
+                return;
+
+            Party.RemoveAt(index);
+        }
+
+        public void SwapPosition(int pokemon1, int pokemon2)
+        {
+            var mB = Mathf.Max(pokemon1, pokemon2);
+            var mS = Mathf.Min(pokemon1, pokemon2);
+
+            var p1 = party[mS];
+            party.Insert(mB, p1);
+            var p2 = party[mB + 1];
+            party.Insert(mS, p2);
+            party.RemoveAt(mS + 1);
+            party.RemoveAt(mB + 1);
+
+
+        }
+
+        public Pokemon Retrive(int index)
+        {
+            return (index >= Party.Count) ? null : Party[index];
+        }
+
+
+        public Pokemon GetHealthy()
+        {
+            return Party.Where(x => x.HP > 0).FirstOrDefault();
+        }
+
+
+        public IEnumerator CheckForEvolutions_CR()
+        {
+
+            foreach (var pokemon in party)
+            {
+                var evolution = pokemon.CanEvolveInto();
+                if (evolution != null)
+                {
+                    yield return EvolutionSceneUI.I.StartEvolution_CR(pokemon, evolution);
+                }
+
+            }
+        }
+        public int GetSize() => Party.Count;
+
+
+        public List<Pokemon> GetFullParty()
+        {
+            return Party;
         }
     }
-    public int GetSize() => Party.Count;
 
 
-    public List<Pokemon> GetFullParty()
-    {
-        return Party;
-    }
+
 }
-
-

--- a/Pokemons/PokemonTeam.cs
+++ b/Pokemons/PokemonTeam.cs
@@ -3,56 +3,61 @@ using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
 
-[System.Serializable]
-public class PokemonTeam
+namespace pokeCopy
 {
-    [SerializeField] List<Pokemon> party = new List<Pokemon>();
 
-
-    public void Init()
+    [System.Serializable]
+    public class PokemonTeam
     {
-        foreach (var p in party)
+        [SerializeField] List<Pokemon> party = new List<Pokemon>();
+
+
+        public void Init()
         {
-            p.Init();
+            foreach (var p in party)
+            {
+                p.Init();
+            }
         }
+
+        public void AddToParty(Pokemon p)
+        {
+            if (party.Count >= 6)
+                return;
+
+            party.Add(p);
+
+        }
+        public void RemoveFromParty(int index)
+        {
+            if (party.Count <= 1)
+                return;
+
+            party.RemoveAt(index);
+        }
+
+        public Pokemon Retrive(int index)
+        {
+            return (index >= party.Count) ? null : party[index];
+        }
+
+
+        public Pokemon GetHealthy()
+        {
+            return party.Where(x => x.HP > 0).FirstOrDefault();
+        }
+
+        public int GetSize()
+        {
+            return party.Count;
+        }
+
+        public List<Pokemon> GetFullParty()
+        {
+            return party;
+        }
+
+
     }
-
-    public void AddToParty(Pokemon p)
-    {
-        if (party.Count >= 6)
-            return;
-
-        party.Add(p);
-
-    }
-    public void RemoveFromParty(int index)
-    {
-        if (party.Count <= 1)
-            return;
-
-        party.RemoveAt(index);
-    }
-
-    public Pokemon Retrive(int index)
-    {
-        return (index >= party.Count) ? null : party[index];
-    }
-
-
-    public Pokemon GetHealthy()
-    {
-        return party.Where(x => x.HP > 0).FirstOrDefault();
-    }
-
-    public int GetSize()
-    {
-        return party.Count;
-    }
-
-    public List<Pokemon> GetFullParty()
-    {
-        return party;
-    }
-
-
 }
+

--- a/UI/PartyButonData.cs
+++ b/UI/PartyButonData.cs
@@ -3,176 +3,182 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class PartyButonData : MonoBehaviour
+
+namespace pokeCopy
 {
-    public Pokemon Pokemon { get; set; }
 
-    [SerializeField] GameObject data;
-    [SerializeField] GameObject empty;
-    // [SerializeField] UIColors colors;
-
-    //Consider reuse battleHud code here so part of the data can be dealt altomaticly as the pokemon has its data changed
-
-    [SerializeField] Text lvlText;
-    [SerializeField] Text NameText;
-    [SerializeField] Image chibiImage;
-    [SerializeField] Text HpText;
-    [SerializeField] Slider HpSlider;
-    [SerializeField] Image statusImage;
-    [SerializeField] Text statusText;
-    [SerializeField] Text[] moveTexts;
-    [SerializeField] Text[] movePP;
-    [SerializeField] Image type1Icon;
-    [SerializeField] Image type2Icon;
-    [SerializeField] Text ableText;
-    public Button Button { get; private set; }
-
-    [SerializeField] BattleHud hud;
-
-    public void Start()
+    public class PartyButonData : MonoBehaviour
     {
-        Button = GetComponent<Button>();
+        public Pokemon Pokemon { get; set; }
 
+        [SerializeField] GameObject data;
+        [SerializeField] GameObject empty;
+        // [SerializeField] UIColors colors;
 
-    }
+        //Consider reuse battleHud code here so part of the data can be dealt altomaticly as the pokemon has its data changed
 
-    public void SetUpPkmnInfo(Pokemon pkmn)
-    {
-        Pokemon = pkmn;
-        Button = GetComponent<Button>();
-        hud = GetComponent<BattleHud>();
+        [SerializeField] Text lvlText;
+        [SerializeField] Text NameText;
+        [SerializeField] Image chibiImage;
+        [SerializeField] Text HpText;
+        [SerializeField] Slider HpSlider;
+        [SerializeField] Image statusImage;
+        [SerializeField] Text statusText;
+        [SerializeField] Text[] moveTexts;
+        [SerializeField] Text[] movePP;
+        [SerializeField] Image type1Icon;
+        [SerializeField] Image type2Icon;
+        [SerializeField] Text ableText;
+        public Button Button { get; private set; }
 
-        if (Pokemon == null)
+        [SerializeField] BattleHud hud;
+
+        public void Start()
         {
+            Button = GetComponent<Button>();
+
+
+        }
+
+        public void SetUpPkmnInfo(Pokemon pkmn)
+        {
+            Pokemon = pkmn;
+            Button = GetComponent<Button>();
+            hud = GetComponent<BattleHud>();
+
+            if (Pokemon == null)
+            {
+                if (data != null)
+                {
+                    data.SetActive(false);
+                    empty.SetActive(true);
+                    gameObject.GetComponent<Button>().interactable = false;
+                    return;
+
+                }
+                gameObject.SetActive(false);
+                return;
+            }
+
+            gameObject.GetComponent<Button>().interactable = true;
             if (data != null)
             {
-                data.SetActive(false);
-                empty.SetActive(true);
-                gameObject.GetComponent<Button>().interactable = false;
-                return;
 
+                data.SetActive(true);
+                empty.SetActive(false);
             }
-            gameObject.SetActive(false);
-            return;
-        }
 
-        gameObject.GetComponent<Button>().interactable = true;
-        if (data != null)
-        {
+            //TO DO: Reuse BattleHUD script to update data here
+            pkmn.OnHPChange += UpdateHPValue;
 
-            data.SetActive(true);
-            empty.SetActive(false);
-        }
+            lvlText.text = $"Lvl {Pokemon.Level}";
+            NameText.text = Pokemon.NickName;
 
-        //TO DO: Reuse BattleHUD script to update data here
-        pkmn.OnHPChange += UpdateHPValue;
+            chibiImage.sprite = (Pokemon.Base.Chibi) ? Pokemon.Base.Chibi : Pokemon.Base.Front;
 
-        lvlText.text = $"Lvl {Pokemon.Level}";
-        NameText.text = Pokemon.NickName;
+            HpText.text = $"{Pokemon.HP}/{Pokemon.MaxHP}";
+            HpSlider.maxValue = Pokemon.MaxHP;
+            HpSlider.value = Pokemon.HP;
 
-        chibiImage.sprite = (Pokemon.Base.Chibi) ? Pokemon.Base.Chibi : Pokemon.Base.Front;
-
-        HpText.text = $"{Pokemon.HP}/{Pokemon.MaxHP}";
-        HpSlider.maxValue = Pokemon.MaxHP;
-        HpSlider.value = Pokemon.HP;
-
-        if (moveTexts.Length > 0 && movePP.Length > 0)
-        {
-            for (int i = 0; i < moveTexts.Length; i++)
+            if (moveTexts.Length > 0 && movePP.Length > 0)
             {
-                if (i >= Pokemon.MoveSet.Count)
+                for (int i = 0; i < moveTexts.Length; i++)
                 {
-                    moveTexts[i].text = "-";
-                    movePP[i].text = "-/-";
-                    continue;
+                    if (i >= Pokemon.MoveSet.Count)
+                    {
+                        moveTexts[i].text = "-";
+                        movePP[i].text = "-/-";
+                        continue;
+                    }
+                    moveTexts[i].text = Pokemon.MoveSet[i].Base.name;
+                    movePP[i].text = $"{Pokemon.MoveSet[i].Pp}/{Pokemon.MoveSet[i].Base.MaxPP}";
                 }
-                moveTexts[i].text = Pokemon.MoveSet[i].Base.name;
-                movePP[i].text = $"{Pokemon.MoveSet[i].Pp}/{Pokemon.MoveSet[i].Base.MaxPP}";
             }
+
+
+            if (type1Icon != null)
+            {
+                type1Icon.sprite = UIColors.typeIcons[pkmn.Base.Type1];
+            }
+            if (type2Icon != null)
+            {
+
+                type2Icon.sprite = UIColors.typeIcons[pkmn.Base.Type2];
+                if (type2Icon.sprite == null)
+                    type2Icon.gameObject.SetActive(false);
+                else
+                    type2Icon.gameObject.SetActive(true);
+            }
+
+
+            UpdateStatusCondition();
+
+            UpdateHPColors();
+
         }
 
-
-        if (type1Icon != null)
-        {
-            type1Icon.sprite = UIColors.typeIcons[pkmn.Base.Type1];
-        }
-        if (type2Icon != null)
-        {
-
-            type2Icon.sprite = UIColors.typeIcons[pkmn.Base.Type2];
-            if (type2Icon.sprite == null)
-                type2Icon.gameObject.SetActive(false);
-            else
-                type2Icon.gameObject.SetActive(true);
-        }
-
-        
-        UpdateStatusCondition();
-
-        UpdateHPColors();
-
-    }
-
-    public void SetLeanrableMove(bool isLearnable)
-    {
-        statusImage.gameObject.SetActive(false);
-        ableText.gameObject.SetActive(true);
-        ableText.text = (isLearnable) ? "ABLE!" : "UNABLE";
-
-    }
-
-    void UpdateHPValue()
-    {
-        HpText.text = $"{Pokemon.HP}/{Pokemon.MaxHP}";
-        HpSlider.maxValue = Pokemon.MaxHP;
-        HpSlider.value = Pokemon.HP;
-
-        UpdateHPColors();
-
-    }
-
-    void UpdateHPColors()
-    {
-        var hpFill = HpSlider.fillRect.GetComponent<Image>();
-
-        if (HpSlider.value <= HpSlider.maxValue * 0.25f)
-            hpFill.color = UIColors.hpStateColor[HpState.danger];
-        else if (HpSlider.value <= HpSlider.maxValue * 0.5f)
-            hpFill.color = UIColors.hpStateColor[HpState.caution];
-        else
-            hpFill.color = UIColors.hpStateColor[HpState.healthy];
-
-        if (Pokemon.HP <= 0)
-            Button.colors = UIColors.partyMenuFaintColors;
-        else
-            Button.colors = UIColors.partyMenuNormalColors;
-
-    }
-
-    void UpdateStatusCondition()
-    {
-        var pkmn = Pokemon;
-        if (pkmn.Status == null)
+        public void SetLeanrableMove(bool isLearnable)
         {
             statusImage.gameObject.SetActive(false);
-            statusText.text = "";
+            ableText.gameObject.SetActive(true);
+            ableText.text = (isLearnable) ? "ABLE!" : "UNABLE";
 
         }
-        else
+
+        void UpdateHPValue()
         {
-            statusImage.gameObject.SetActive(true);
+            HpText.text = $"{Pokemon.HP}/{Pokemon.MaxHP}";
+            HpSlider.maxValue = Pokemon.MaxHP;
+            HpSlider.value = Pokemon.HP;
 
-            statusImage.color = UIColors.statusColors[pkmn.Status.Id];
+            UpdateHPColors();
 
-            statusText.text = pkmn.Status.Id.ToString().ToUpper();
         }
-        
+
+        void UpdateHPColors()
+        {
+            var hpFill = HpSlider.fillRect.GetComponent<Image>();
+
+            if (HpSlider.value <= HpSlider.maxValue * 0.25f)
+                hpFill.color = UIColors.hpStateColor[HpState.danger];
+            else if (HpSlider.value <= HpSlider.maxValue * 0.5f)
+                hpFill.color = UIColors.hpStateColor[HpState.caution];
+            else
+                hpFill.color = UIColors.hpStateColor[HpState.healthy];
+
+            if (Pokemon.HP <= 0)
+                Button.colors = UIColors.partyMenuFaintColors;
+            else
+                Button.colors = UIColors.partyMenuNormalColors;
+
+        }
+
+        void UpdateStatusCondition()
+        {
+            var pkmn = Pokemon;
+            if (pkmn.Status == null)
+            {
+                statusImage.gameObject.SetActive(false);
+                statusText.text = "";
+
+            }
+            else
+            {
+                statusImage.gameObject.SetActive(true);
+
+                statusImage.color = UIColors.statusColors[pkmn.Status.Id];
+
+                statusText.text = pkmn.Status.Id.ToString().ToUpper();
+            }
 
 
-        if (ableText)
-            ableText.gameObject.SetActive(false);
+
+            if (ableText)
+                ableText.gameObject.SetActive(false);
+
+        }
+
 
     }
-
-
 }
+

--- a/UI/PartyInfoPanelUI.cs
+++ b/UI/PartyInfoPanelUI.cs
@@ -3,92 +3,96 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class PartyInfoPanelUI : MonoBehaviour
+namespace pokeCopy
 {
-    [SerializeField] Image pkmnImage;
-    [SerializeField] Image type1;
-    [SerializeField] Image type2;
-    [SerializeField] Text[] moveName;
-    [SerializeField] Text[] ppText;
-    [SerializeField] Image[] moveType;
-    [SerializeField] Slider XpBar;
-    [SerializeField] Text xPtext;
-    [SerializeField] GameObject noSelectionPanel;
-    //Change color of move button to mactch type
 
-    // Update is called once per frame
-    public void UpdateInfoPanel(Pokemon pkmn)
+    public class PartyInfoPanelUI : MonoBehaviour
     {
-        if (pkmn != null)
+        [SerializeField] Image pkmnImage;
+        [SerializeField] Image type1;
+        [SerializeField] Image type2;
+        [SerializeField] Text[] moveName;
+        [SerializeField] Text[] ppText;
+        [SerializeField] Image[] moveType;
+        [SerializeField] Slider XpBar;
+        [SerializeField] Text xPtext;
+        [SerializeField] GameObject noSelectionPanel;
+        //Change color of move button to mactch type
+
+        // Update is called once per frame
+        public void UpdateInfoPanel(Pokemon pkmn)
         {
-
-            if (noSelectionPanel)
-                noSelectionPanel.SetActive(false);
-
-            pkmnImage.sprite = pkmn.Base.Front;
-            for (int i = 0; i < moveName.Length; i++)
+            if (pkmn != null)
             {
-                if (pkmn == null || i >= pkmn.MoveSet.Count)
+
+                if (noSelectionPanel)
+                    noSelectionPanel.SetActive(false);
+
+                pkmnImage.sprite = pkmn.Base.Front;
+                for (int i = 0; i < moveName.Length; i++)
                 {
-                    moveName[i].text = "-";
-                    ppText[i].text = "-/-";
-                    ppText[i].rectTransform.localPosition = new Vector3(ppText[i].rectTransform.localPosition.x, -3.814697e-06f);
-                    moveType[i].gameObject.SetActive(false);
-                    continue;
+                    if (pkmn == null || i >= pkmn.MoveSet.Count)
+                    {
+                        moveName[i].text = "-";
+                        ppText[i].text = "-/-";
+                        ppText[i].rectTransform.localPosition = new Vector3(ppText[i].rectTransform.localPosition.x, -3.814697e-06f);
+                        moveType[i].gameObject.SetActive(false);
+                        continue;
+                    }
+                    var pkmnMove = pkmn.MoveSet[i];
+
+                    moveName[i].text = pkmnMove.Base.name;
+                    ppText[i].text = $"{pkmnMove.Pp}/{pkmnMove.Base.MaxPP}";
+                    ppText[i].rectTransform.localPosition = new Vector3(ppText[i].rectTransform.localPosition.x, 12.2f);
+                    moveType[i].gameObject.SetActive(true);
+                    moveType[i].sprite = UIColors.typeIcons[pkmnMove.Base.Type];
+
+
+
                 }
-                var pkmnMove = pkmn.MoveSet[i];
-
-                moveName[i].text = pkmnMove.Base.name;
-                ppText[i].text = $"{pkmnMove.Pp}/{pkmnMove.Base.MaxPP}";
-                ppText[i].rectTransform.localPosition = new Vector3(ppText[i].rectTransform.localPosition.x, 12.2f);
-                moveType[i].gameObject.SetActive(true);
-                moveType[i].sprite = UIColors.typeIcons[pkmnMove.Base.Type];
+                type1.sprite = UIColors.typeIcons[pkmn.Base.Type1];
 
 
+                type2.sprite = UIColors.typeIcons[pkmn.Base.Type2];
+                if (type2.sprite == null)
+                {
+                    type1.rectTransform.localPosition = new Vector3(-275f, type1.rectTransform.localPosition.y);
+                    type2.gameObject.SetActive(false);
+                }
+                else
+                {
+                    type1.rectTransform.localPosition = new Vector3(-323.4f, type1.rectTransform.localPosition.y);
 
-            }
-            type1.sprite = UIColors.typeIcons[pkmn.Base.Type1];
+                    type2.gameObject.SetActive(true);
+                }
+
+                if (XpBar != null && xPtext != null)
+                {
+                    int crntLvlXP = pkmn.Base.GetExpForLevel(pkmn.Level);
+                    int nxtLvlXP = pkmn.Base.GetExpForLevel(pkmn.Level + 1);
+                    //Debug.Log($" crrt {crntLvlXP}");
+                    //Debug.Log($" nxt {nxtLvlXP}");
 
 
-            type2.sprite = UIColors.typeIcons[pkmn.Base.Type2];
-            if (type2.sprite == null)
-            {
-                type1.rectTransform.localPosition = new Vector3(-275f, type1.rectTransform.localPosition.y);
-                type2.gameObject.SetActive(false);
+                    XpBar.value = (pkmn.Exp - crntLvlXP) / (float)(nxtLvlXP - crntLvlXP);
+                    //Debug.Log(XpBar.value);
+                    xPtext.text = $"{pkmn.Exp}/{nxtLvlXP}";
+                }
+
             }
             else
             {
-                type1.rectTransform.localPosition = new Vector3(-323.4f, type1.rectTransform.localPosition.y);
+                if (noSelectionPanel)
+                    noSelectionPanel.SetActive(true);
 
-                type2.gameObject.SetActive(true);
-            }
-
-            if (XpBar != null && xPtext != null)
-            {
-                int crntLvlXP = pkmn.Base.GetExpForLevel(pkmn.Level);
-                int nxtLvlXP = pkmn.Base.GetExpForLevel(pkmn.Level + 1);
-                //Debug.Log($" crrt {crntLvlXP}");
-                //Debug.Log($" nxt {nxtLvlXP}");
-
-
-                XpBar.value = (pkmn.Exp - crntLvlXP) / (float)(nxtLvlXP - crntLvlXP);
-                //Debug.Log(XpBar.value);
-                xPtext.text = $"{pkmn.Exp}/{nxtLvlXP}";
+                return;
             }
 
         }
-        else
-        {
-            if (noSelectionPanel)
-                noSelectionPanel.SetActive(true);
 
-            return;
-        }
+
+
+
 
     }
-
-
-
-
-
 }

--- a/UI/PartyScreenUI.cs
+++ b/UI/PartyScreenUI.cs
@@ -7,341 +7,345 @@ using UnityEngine.InputSystem.UI;
 using System.Linq;
 using pokeCopy;
 
-public class PartyScreenUI : MonoBehaviour, IGameScreen
+namespace pokeCopy
 {
-    [SerializeField] SceneData BattleSceneData;
-    [SerializeField] BattleData battleData;
-
-    PokemonParty playerParty;
-    [SerializeField] Text intructs;
-
-    [SerializeField] GameObject confirmMenu;
-    [SerializeField] GameObject battleConfirmMenu;// how to do without referencing dependency injection
-    [SerializeField] GameObject inventoryUI;
-
-
-    [SerializeField] PartyInfoPanelUI infoPanel;
-    [SerializeField] EventSystem controller;
-    [SerializeField] Image type1;
-    [SerializeField] Image type2;
-
-    [SerializeField] PartyButonData[] team;
-
-    public Pokemon SelectedPokemon { get; set; }
-    public GameObject ConfirmMenu => confirmMenu;
-
-    public GameObject BattleConfirmMenu => battleConfirmMenu;
-
-    public GameObject InventoryUI => inventoryUI;
-
-    public PartyButonData[] Team  => team; 
-
-    bool reorderingParty;
-    int switchIndex;
-
-    bool isTmHmSelection;
-
-    InputSystemUIInputModule input;
-
-    System.Action OnSelectPokemon;
-    // System.Func<bool> OnCancelButton;
-    System.Action OnCancelButton;
-
-    public void Awake()
+    public class PartyScreenUI : MonoBehaviour, IGameScreen
     {
-        //team = new PartyButonData[6];
-        team = GetComponentsInChildren<PartyButonData>(true);
-        if (controller == null)
-            controller = EventSystem.current;
+        [SerializeField] SceneData BattleSceneData;
+        [SerializeField] BattleData battleData;
 
-    }
+        PokemonParty playerParty;
+        [SerializeField] Text intructs;
+
+        [SerializeField] GameObject confirmMenu;
+        [SerializeField] GameObject battleConfirmMenu;// how to do without referencing dependency injection
+        [SerializeField] GameObject inventoryUI;
 
 
+        [SerializeField] PartyInfoPanelUI infoPanel;
+        [SerializeField] EventSystem controller;
+        [SerializeField] Image type1;
+        [SerializeField] Image type2;
 
-    public void OnEnable()//refactor and update only on changes
-    {
-        // team = GetComponentsInChildren<PartyButonData>(true);
-        //playerParty = BattleSceneData.RetrivePlayerParty();
-        //playerParty = battleData.GetPlayerParty();
+        [SerializeField] PartyButonData[] team;
 
-        //playerParty = BattleSceneData.RetrivePlayerParty();
+        public Pokemon SelectedPokemon { get; set; }
+        public GameObject ConfirmMenu => confirmMenu;
 
-        if (playerParty == null)
+        public GameObject BattleConfirmMenu => battleConfirmMenu;
+
+        public GameObject InventoryUI => inventoryUI;
+
+        public PartyButonData[] Team => team;
+
+        bool reorderingParty;
+        int switchIndex;
+
+        bool isTmHmSelection;
+
+        InputSystemUIInputModule input;
+
+        System.Action OnSelectPokemon;
+        // System.Func<bool> OnCancelButton;
+        System.Action OnCancelButton;
+
+        public void Awake()
         {
-            if (battleData)
-                playerParty = battleData.GetPlayerParty();
-            if (playerParty == null && GameManager.Instance.Player)
-                SetPartyData(GameManager.Instance.Player.GetComponent<PokemonParty>());
+            //team = new PartyButonData[6];
+            team = GetComponentsInChildren<PartyButonData>(true);
+            if (controller == null)
+                controller = EventSystem.current;
+
         }
 
 
-        for (int i = 0; i < team.Length; i++)
+
+        public void OnEnable()//refactor and update only on changes
         {
-            team[i].SetUpPkmnInfo(playerParty.Retrive(i));
-        }
-        SelectedPokemon = null;
+            // team = GetComponentsInChildren<PartyButonData>(true);
+            //playerParty = BattleSceneData.RetrivePlayerParty();
+            //playerParty = battleData.GetPlayerParty();
 
-        if (input == null)
-            input = EventSystem.current.GetComponent<InputSystemUIInputModule>();
+            //playerParty = BattleSceneData.RetrivePlayerParty();
 
-
-
-        controller.SetSelectedGameObject(team[0].gameObject);
-        if (infoPanel != null)
-        {
-            infoPanel.UpdateInfoPanel(controller.currentSelectedGameObject.GetComponent<PartyButonData>().Pokemon);
-        }
-        controller.currentSelectedGameObject.GetComponent<Button>().OnSelect(null);
-    }
-
-    public void SetPartyData(PokemonParty party)
-    {
-        playerParty = party;
-    }
+            if (playerParty == null)
+            {
+                if (battleData)
+                    playerParty = battleData.GetPlayerParty();
+                if (playerParty == null && GameManager.Instance.Player)
+                    SetPartyData(GameManager.Instance.Player.GetComponent<PokemonParty>());
+            }
 
 
-    public void SetButtons(System.Action pokemonSelectionAction, System.Action cancelButtonAction, GameObject battleSelectionMenu = null)
-    {
-        //Debug.Log("Seted Buttons on party menu");
-        //Set a function to open sub menu if pokemonSelection is Null
-        if (pokemonSelectionAction != null)
-            OnSelectPokemon = pokemonSelectionAction;
-
-        if (OnSelectPokemon == null)
-            OnSelectPokemon = OpenSelectionMenu;
-
-        //Debug.Log(OnSelectPokemon?.Method);
-
-        if (cancelButtonAction != null && OnCancelButton == null)
-            OnCancelButton = cancelButtonAction;
-
-        //Debug.Log(OnCancelButton?.Method);
-        if (battleSelectionMenu != null)
-            SetBattleSelectionMenu(battleSelectionMenu);
-    }
-
-    public void SetBattleSelectionMenu(GameObject battleSelectionMenu) => battleConfirmMenu = battleSelectionMenu;
-
-
-
-    public void Open(System.Action pokemonSelectionAction = null, System.Action cancelButtonAction = null)
-    {
-        if (pokemonSelectionAction != null || cancelButtonAction != null)
-            SetButtons(pokemonSelectionAction, cancelButtonAction);
-        gameObject.SetActive(true);
-    }
-
-
-    public void SetSelectionAction(System.Action onSelection)
-    {
-        OnSelectPokemon = onSelection;
-    }
-
-    public void SelectPkmn()//on button using inspector RENAME: SelectPkmnButton
-    {
-        var selection = EventSystem.current.currentSelectedGameObject.GetComponent<PartyButonData>();
-        SelectedPokemon = selection.Pokemon;
-
-        SetPressedButtonColors(selection.Button);
-
-        //contextual function
-        OnSelectPokemon?.Invoke();
-        switchIndex = GetSelectedPartyIndex();
-
-    }
-
-    public void SetAble(MovesBase move)
-    {
-        for (int i = 0; i < team.Count(); i++)
-        {
-            var poke = team[i].Pokemon;
-            if (poke != null)
-                team[i].SetLeanrableMove(poke.Base.TM_n_HM_Leanrnables.Contains(move));// && poke.HasMove(move));
-        }
-    }
-
-    void SetPressedButtonColors(Button button)
-    {
-        if (reorderingParty)
-            return;
-        ColorBlock cb = button.colors;
-        cb.normalColor = cb.pressedColor;
-        button.colors = cb;
-
-
-        //change normal color when button is pressed
-
-
-    }
-
-
-    // Update is called once per frame
-    void Update()
-    {
-        HandleUpdate();
-
-    }
-
-    public void HandleUpdate()
-    {
-        //control summary screen here via HandleUpdate function on summarry screen class
-
-        if (input.move.action.triggered && infoPanel != null && (!confirmMenu.activeSelf))//input.move.ToInputAction().ReadValue<Vector2>() != Vector2.zero)
-        {
-            if (battleConfirmMenu && battleConfirmMenu.activeSelf)
-                return;
-
-            var crrntSele = controller.currentSelectedGameObject.GetComponent<PartyButonData>();
-            if (crrntSele != null)
-                infoPanel.UpdateInfoPanel(crrntSele.Pokemon);
-            else
-                infoPanel.UpdateInfoPanel(null);
-
-        }
-
-    }
-
-
-    public void OpenSelectionMenu()
-    {
-        confirmMenu.SetActive(true);
-        EventSystem.current.SetSelectedGameObject(confirmMenu.GetComponentInChildren<Button>().gameObject);
-    }
-
-
-
-    public void SummaryButton()
-    {
-
-    }
-
-
-    public void SwitchButton()
-    {
-        if (GameManager.Instance.State != GameState.Menu)
-            return;
-
-        ColorBlock cb = team[switchIndex].Button.colors;
-        reorderingParty = true;
-        confirmMenu.SetActive(false);
-        EventSystem.current.SetSelectedGameObject(team[switchIndex].gameObject);
-        cb.normalColor = cb.pressedColor;
-        team[switchIndex].Button.colors = cb;
-        OnSelectPokemon = MovePokemon;
-
-
-    }
-
-    public void MovePokemon()
-    {
-        if (GetSelectedPartyIndex() != switchIndex)
-        {
-            var selIndex = GetSelectedPartyIndex();
-            playerParty.SwapPosition(switchIndex, GetSelectedPartyIndex());
             for (int i = 0; i < team.Length; i++)
             {
-                if (i == switchIndex || i == selIndex)
-                    team[i].SetUpPkmnInfo(playerParty.Retrive(i));
+                team[i].SetUpPkmnInfo(playerParty.Retrive(i));
             }
+            SelectedPokemon = null;
 
+            if (input == null)
+                input = EventSystem.current.GetComponent<InputSystemUIInputModule>();
+
+
+
+            controller.SetSelectedGameObject(team[0].gameObject);
             if (infoPanel != null)
+            {
                 infoPanel.UpdateInfoPanel(controller.currentSelectedGameObject.GetComponent<PartyButonData>().Pokemon);
+            }
+            controller.currentSelectedGameObject.GetComponent<Button>().OnSelect(null);
         }
-        team[switchIndex].Button.colors = (team[switchIndex].Pokemon.HP > 0) ? UIColors.partyMenuNormalColors : UIColors.partyMenuFaintColors;
-        reorderingParty = false;
-        OnSelectPokemon = OpenSelectionMenu;
 
-    }
+        public void SetPartyData(PokemonParty party)
+        {
+            playerParty = party;
+        }
+
+
+        public void SetButtons(System.Action pokemonSelectionAction, System.Action cancelButtonAction, GameObject battleSelectionMenu = null)
+        {
+            //Debug.Log("Seted Buttons on party menu");
+            //Set a function to open sub menu if pokemonSelection is Null
+            if (pokemonSelectionAction != null)
+                OnSelectPokemon = pokemonSelectionAction;
+
+            if (OnSelectPokemon == null)
+                OnSelectPokemon = OpenSelectionMenu;
+
+            //Debug.Log(OnSelectPokemon?.Method);
+
+            if (cancelButtonAction != null && OnCancelButton == null)
+                OnCancelButton = cancelButtonAction;
+
+            //Debug.Log(OnCancelButton?.Method);
+            if (battleSelectionMenu != null)
+                SetBattleSelectionMenu(battleSelectionMenu);
+        }
+
+        public void SetBattleSelectionMenu(GameObject battleSelectionMenu) => battleConfirmMenu = battleSelectionMenu;
 
 
 
-    public void CancelButton()
-    {
-        if (GameManager.Instance.State == GameState.Menu)
+        public void Open(System.Action pokemonSelectionAction = null, System.Action cancelButtonAction = null)
+        {
+            if (pokemonSelectionAction != null || cancelButtonAction != null)
+                SetButtons(pokemonSelectionAction, cancelButtonAction);
+            gameObject.SetActive(true);
+        }
+
+
+        public void SetSelectionAction(System.Action onSelection)
+        {
+            OnSelectPokemon = onSelection;
+        }
+
+        public void SelectPkmn()//on button using inspector RENAME: SelectPkmnButton
+        {
+            var selection = EventSystem.current.currentSelectedGameObject.GetComponent<PartyButonData>();
+            SelectedPokemon = selection.Pokemon;
+
+            SetPressedButtonColors(selection.Button);
+
+            //contextual function
+            OnSelectPokemon?.Invoke();
+            switchIndex = GetSelectedPartyIndex();
+
+        }
+
+        public void SetAble(MovesBase move)
+        {
+            for (int i = 0; i < team.Count(); i++)
+            {
+                var poke = team[i].Pokemon;
+                if (poke != null)
+                    team[i].SetLeanrableMove(poke.Base.TM_n_HM_Leanrnables.Contains(move));// && poke.HasMove(move));
+            }
+        }
+
+        void SetPressedButtonColors(Button button)
         {
             if (reorderingParty)
-            {
-                reorderingParty = false;
-                OnSelectPokemon = OpenSelectionMenu;
-                ResetPressedButtonColors();
                 return;
-            }
+            ColorBlock cb = button.colors;
+            cb.normalColor = cb.pressedColor;
+            button.colors = cb;
 
-            if (confirmMenu && confirmMenu.activeSelf)
-            {
-                confirmMenu.SetActive(false);
-                EventSystem.current.SetSelectedGameObject(team[switchIndex].gameObject);
-                ResetPressedButtonColors();
-                return;
-            }
 
-            if (inventoryUI && inventoryUI.activeSelf)
-            {
-                inventoryUI.SetActive(false);
-                EventSystem.current.SetSelectedGameObject(team[switchIndex].gameObject);
-                ResetPressedButtonColors();
-                return;
+            //change normal color when button is pressed
 
-            }
 
         }
 
-        if (GameManager.Instance.State == GameState.Battle)
+
+        // Update is called once per frame
+        void Update()
         {
-            if (battleConfirmMenu && battleConfirmMenu.activeSelf)
-            {
+            HandleUpdate();
 
-                battleConfirmMenu.SetActive(false);
-                EventSystem.current.SetSelectedGameObject(team[switchIndex].gameObject);
-                ResetPressedButtonColors();
-                return;
+        }
+
+        public void HandleUpdate()
+        {
+            //control summary screen here via HandleUpdate function on summarry screen class
+
+            if (input.move.action.triggered && infoPanel != null && (!confirmMenu.activeSelf))//input.move.ToInputAction().ReadValue<Vector2>() != Vector2.zero)
+            {
+                if (battleConfirmMenu && battleConfirmMenu.activeSelf)
+                    return;
+
+                var crrntSele = controller.currentSelectedGameObject.GetComponent<PartyButonData>();
+                if (crrntSele != null)
+                    infoPanel.UpdateInfoPanel(crrntSele.Pokemon);
+                else
+                    infoPanel.UpdateInfoPanel(null);
 
             }
+
         }
 
 
-        OnCancelButton?.Invoke();
-        /*
-        if ((bool)OnCancelButton?.Invoke())
-            return;
+        public void OpenSelectionMenu()
+        {
+            confirmMenu.SetActive(true);
+            EventSystem.current.SetSelectedGameObject(confirmMenu.GetComponentInChildren<Button>().gameObject);
+        }
 
-        //gameObject.SetActive(false);
-        */
 
+
+        public void SummaryButton()
+        {
+
+        }
+
+
+        public void SwitchButton()
+        {
+            if (GameManager.Instance.State != GameState.Menu)
+                return;
+
+            ColorBlock cb = team[switchIndex].Button.colors;
+            reorderingParty = true;
+            confirmMenu.SetActive(false);
+            EventSystem.current.SetSelectedGameObject(team[switchIndex].gameObject);
+            cb.normalColor = cb.pressedColor;
+            team[switchIndex].Button.colors = cb;
+            OnSelectPokemon = MovePokemon;
+
+
+        }
+
+        public void MovePokemon()
+        {
+            if (GetSelectedPartyIndex() != switchIndex)
+            {
+                var selIndex = GetSelectedPartyIndex();
+                playerParty.SwapPosition(switchIndex, GetSelectedPartyIndex());
+                for (int i = 0; i < team.Length; i++)
+                {
+                    if (i == switchIndex || i == selIndex)
+                        team[i].SetUpPkmnInfo(playerParty.Retrive(i));
+                }
+
+                if (infoPanel != null)
+                    infoPanel.UpdateInfoPanel(controller.currentSelectedGameObject.GetComponent<PartyButonData>().Pokemon);
+            }
+            team[switchIndex].Button.colors = (team[switchIndex].Pokemon.HP > 0) ? UIColors.partyMenuNormalColors : UIColors.partyMenuFaintColors;
+            reorderingParty = false;
+            OnSelectPokemon = OpenSelectionMenu;
+
+        }
+
+
+
+        public void CancelButton()
+        {
+            if (GameManager.Instance.State == GameState.Menu)
+            {
+                if (reorderingParty)
+                {
+                    reorderingParty = false;
+                    OnSelectPokemon = OpenSelectionMenu;
+                    ResetPressedButtonColors();
+                    return;
+                }
+
+                if (confirmMenu && confirmMenu.activeSelf)
+                {
+                    confirmMenu.SetActive(false);
+                    EventSystem.current.SetSelectedGameObject(team[switchIndex].gameObject);
+                    ResetPressedButtonColors();
+                    return;
+                }
+
+                if (inventoryUI && inventoryUI.activeSelf)
+                {
+                    inventoryUI.SetActive(false);
+                    EventSystem.current.SetSelectedGameObject(team[switchIndex].gameObject);
+                    ResetPressedButtonColors();
+                    return;
+
+                }
+
+            }
+
+            if (GameManager.Instance.State == GameState.Battle)
+            {
+                if (battleConfirmMenu && battleConfirmMenu.activeSelf)
+                {
+
+                    battleConfirmMenu.SetActive(false);
+                    EventSystem.current.SetSelectedGameObject(team[switchIndex].gameObject);
+                    ResetPressedButtonColors();
+                    return;
+
+                }
+            }
+
+
+            OnCancelButton?.Invoke();
+            /*
+            if ((bool)OnCancelButton?.Invoke())
+                return;
+
+            //gameObject.SetActive(false);
+            */
+
+        }
+
+
+
+        public bool TryCloseSubmenu(GameObject subMenu)
+        {
+            if (!subMenu.activeSelf)
+                return false;
+
+            subMenu.SetActive(false);
+            EventSystem.current.SetSelectedGameObject(team[switchIndex].gameObject);
+            ResetPressedButtonColors();
+            return true;
+        }
+
+        public void ResetPressedButtonColors()
+        {
+            team[switchIndex].Button.colors = (team[switchIndex].Pokemon.HP > 0) ? UIColors.partyMenuNormalColors : UIColors.partyMenuFaintColors;
+
+        }
+
+
+        public int GetSelectedPartyIndex()
+        {
+            return playerParty.Party.IndexOf(SelectedPokemon);
+        }
+
+        public GameObject GetGameObject()
+        {
+            return gameObject;
+        }
     }
 
-
-
-    public bool TryCloseSubmenu(GameObject subMenu)
+    public enum PartyMenuState
     {
-        if (!subMenu.activeSelf)
-            return false;
-
-        subMenu.SetActive(false);
-        EventSystem.current.SetSelectedGameObject(team[switchIndex].gameObject);
-        ResetPressedButtonColors();
-        return true;
+        Menu, Battle_Decision, Battle_Fainted, Battle_Optional, Inventory_Selection
     }
 
-    public void ResetPressedButtonColors()
-    {
-        team[switchIndex].Button.colors = (team[switchIndex].Pokemon.HP > 0) ? UIColors.partyMenuNormalColors : UIColors.partyMenuFaintColors;
-
-    }
-    
-
-    public int GetSelectedPartyIndex()
-    {
-        return playerParty.Party.IndexOf(SelectedPokemon);
-    }
-
-    public GameObject GetGameObject()
-    {
-        return gameObject;
-    }
-}
-
-public enum PartyMenuState
-{
-    Menu, Battle_Decision, Battle_Fainted, Battle_Optional, Inventory_Selection
 }


### PR DESCRIPTION
Reorganization and refactoring of code.
- Changed any relevant code from global to 'pokeCopy' namespace
- All coroutines received a suffix '_CR' to indicate there behavior
- Renamed 'PartyMenu' to 'PartyScreenUI' to better inform the script nature
- Renamed Button related logic and data holder with _'script name'_ + 'ButtonData'

In the future:
- Clean up code and any use of pokeCopy namespace that is redundant
- Rename methods and fields to better describe their functions
- Refactor to improve readability and organization
